### PR TITLE
fix bugs of graph building & optimize debug code

### DIFF
--- a/rap/src/analysis/core/dataflow.rs
+++ b/rap/src/analysis/core/dataflow.rs
@@ -52,8 +52,15 @@ impl<'tcx> DataFlow<'tcx> {
     }
 
     pub fn draw_graphs(&self) {
+        let dir_name = "DataflowGraph";
+
+        Command::new("rm")
+        .args(&["-rf", dir_name])
+        .output()
+        .expect("Failed to remove directory.");
+
         Command::new("mkdir")
-        .args(&["DataflowGraph"])
+        .args(&[dir_name])
         .output()
         .expect("Failed to create directory.");
 

--- a/rap/src/analysis/core/dataflow/debug.rs
+++ b/rap/src/analysis/core/dataflow/debug.rs
@@ -1,0 +1,122 @@
+use std::fmt::Write;
+
+use rustc_middle::ty::TyCtxt;
+use rustc_middle::mir::Local;
+
+use super::graph::{GraphEdge, GraphNode, Graph, NodeOp, AggKind};
+
+fn escaped_string(s: String) -> String{
+    s
+        .replace("{", "\\{")
+        .replace("}", "\\}")
+        .replace("<", "\\<")
+        .replace(">", "\\>")
+        .replace("\"", "\\\"")
+}
+
+impl GraphEdge {
+    pub fn to_dot_graph<'tcx> (&self) -> String {
+
+        let mut attr = String::new();
+        let mut dot = String::new();
+        match self { //label=xxx
+            GraphEdge::NodeEdge { src:_, dst:_, op } => {write!(attr, "label=\"{}\" ", escaped_string(format!("{:?}", op))).unwrap();},
+            GraphEdge::ConstEdge { src:_, dst:_, op } => {write!(attr, "label=\"{}\" ", escaped_string(format!("{:?}", op))).unwrap();},
+        }
+        match self {
+            GraphEdge::NodeEdge { src, dst, op:_ } => {write!(dot, "{:?} -> {:?} [{}]", src, dst, attr).unwrap();},
+            GraphEdge::ConstEdge { src, dst, op:_ } => {write!(dot, "{:?} -> {:?} [{}]", src, dst, attr).unwrap();},
+        }
+        dot
+    }
+}
+
+impl GraphNode {
+    pub fn to_dot_graph<'tcx> (&self, tcx: &TyCtxt<'tcx>, local: Local, color: Option<String>, is_marker: bool) -> String {
+        let mut attr = String::new();
+        let mut dot = String::new();
+        match self.op { //label=xxx
+            NodeOp::Nop => {
+                if is_marker{
+                    write!(attr, "label=\"\" style=dashed ").unwrap();
+                }
+                else {
+                    write!(attr, "label=\"<f0> {:?}\" ", local).unwrap();
+                }
+            },
+            NodeOp::Call(def_id) => {
+                let func_name = tcx.def_path_str(def_id);
+                if is_marker {
+                    write!(attr, "label=\"fn {}\" style=dashed ", escaped_string(func_name)).unwrap();
+                }
+                else {
+                    write!(attr, "label=\"<f0> {:?} | <f1> fn {}\" ", local, escaped_string(func_name)).unwrap();
+                }
+            },
+            NodeOp::Aggregate(agg_kind) => {
+                match agg_kind {
+                    AggKind::Adt(def_id) => {
+                        let agg_name = format!("{}::{{..}}", tcx.def_path_str(def_id));
+                        if is_marker {
+                            write!(attr, "label=\"Agg {}\" style=dashed ", escaped_string(agg_name)).unwrap();
+                        }
+                        else {
+                            write!(attr, "label=\"<f0> {:?} | <f1> Agg {}\" ", local, escaped_string(agg_name)).unwrap();
+                        }
+                    },
+                    _ => {
+                        if is_marker {
+                            write!(attr, "label=\"{:?}\" style=dashed ", agg_kind).unwrap();
+                        }
+                        else {
+                            write!(attr, "label=\"<f0> {:?} | {:?}\" ", local, agg_kind).unwrap();
+                        }
+                    }
+                }
+            }
+            _ => {
+                if is_marker {
+                    write!(attr, "label=\"<f1> {:?}\" style=dashed ", self.op).unwrap();
+                }
+                else {
+                    write!(attr, "label=\"<f0> {:?} | <f1> {:?}\" ", local, self.op).unwrap();
+                }
+            },
+        };
+        match color { //color=xxx
+            None => {},
+            Some(color) => {write!(attr, "color={} ", color).unwrap();},
+        }
+        write!(dot, "{:?} [{}]", local, attr).unwrap();
+        dot
+    }
+}
+
+impl Graph {
+    pub fn to_dot_graph<'tcx>(&self, tcx: &TyCtxt<'tcx>) -> String {
+        let mut dot = String::new();
+        let name = tcx.def_path_str(self.def_id);
+
+        writeln!(dot, "digraph \"{}\" {{", &name).unwrap();
+        writeln!(dot, "    node [shape=record];").unwrap();
+        for (local, node) in self.nodes.iter_enumerated() {
+            let node_dot = if local <= Local::from_usize(self.argc) {
+                node.to_dot_graph(tcx, local, Some(String::from("red")), false)
+            }
+            else if local <= Local::from_usize(self.n_locals) {
+                node.to_dot_graph(tcx, local, None, false)
+            }
+            else {
+                node.to_dot_graph(tcx, local, None, true)
+            };
+            writeln!(dot, "    {}", node_dot).unwrap();
+        }
+        //edges
+        for edge in self.edges.iter() {
+            let edge_dot = edge.to_dot_graph();
+            writeln!(dot, "    {}", edge_dot).unwrap();
+        }
+        writeln!(dot, "}}").unwrap();
+        dot
+    }
+}

--- a/rap/src/analysis/core/dataflow/graph.rs
+++ b/rap/src/analysis/core/dataflow/graph.rs
@@ -1,10 +1,9 @@
 use std::cell::Cell;
 use std::collections::HashSet;
-use std::fmt::Write;
 
 use rustc_index::IndexVec;
 use rustc_middle::mir::{TerminatorKind, StatementKind, Operand, Rvalue, Local, Const, BorrowKind, AggregateKind, Mutability, PlaceElem, Place};
-use rustc_middle::ty::{TyKind, TyCtxt};
+use rustc_middle::ty::TyKind;
 use rustc_hir::def_id::DefId;
 
 #[derive(Clone, Debug)]
@@ -61,108 +60,16 @@ pub enum GraphEdge {
     }
 }
 
-impl GraphEdge {
-    pub fn to_dot_graph<'tcx> (&self) -> String {
-        fn escaped_string(s: String) -> String{
-            s
-                .replace("{", "\\{")
-                .replace("}", "\\}")
-                .replace("<", "\\<")
-                .replace(">", "\\>")
-                .replace("\"", "\\\"")
-        }
-
-        let mut attr = String::new();
-        let mut dot = String::new();
-        match self { //label=xxx
-            GraphEdge::NodeEdge { src:_, dst:_, op } => {write!(attr, "label=\"{}\" ", escaped_string(format!("{:?}", op))).unwrap();},
-            GraphEdge::ConstEdge { src:_, dst:_, op } => {write!(attr, "label=\"{}\" ", escaped_string(format!("{:?}", op))).unwrap();},
-        }
-        match self {
-            GraphEdge::NodeEdge { src, dst, op:_ } => {write!(dot, "{:?} -> {:?} [{}]", src, dst, attr).unwrap();},
-            GraphEdge::ConstEdge { src, dst, op:_ } => {write!(dot, "{:?} -> {:?} [{}]", src, dst, attr).unwrap();},
-        }
-        dot
-    }
-}
-
 #[derive(Clone)]
 pub struct GraphNode {
-    op: NodeOp,
-    out_edges: Vec<EdgeIdx>,
-    in_edges: Vec<EdgeIdx>,
+    pub op: NodeOp,
+    pub out_edges: Vec<EdgeIdx>,
+    pub in_edges: Vec<EdgeIdx>,
 }
 
 impl GraphNode {
     pub fn new() -> Self {
         Self { op: NodeOp::Nop, out_edges: vec![], in_edges: vec![] }
-    }
-
-    pub fn to_dot_graph<'tcx> (&self, tcx: &TyCtxt<'tcx>, local: Local, color: Option<String>, is_marker: bool) -> String {
-        fn escaped_string(s: String) -> String{
-            s
-                .replace("{", "\\{")
-                .replace("}", "\\}")
-                .replace("<", "\\<")
-                .replace(">", "\\>")
-        }
-
-        let mut attr = String::new();
-        let mut dot = String::new();
-        match self.op { //label=xxx
-            NodeOp::Nop => {
-                if is_marker{
-                    write!(attr, "label=\"\" style=dashed ").unwrap();
-                }
-                else {
-                    write!(attr, "label=\"<f0> {:?}\" ", local).unwrap();
-                }
-            },
-            NodeOp::Call(def_id) => {
-                let func_name = tcx.def_path_str(def_id);
-                if is_marker {
-                    write!(attr, "label=\"fn {}\" style=dashed ", escaped_string(func_name)).unwrap();
-                }
-                else {
-                    write!(attr, "label=\"<f0> {:?} | <f1> fn {}\" ", local, escaped_string(func_name)).unwrap();
-                }
-            },
-            NodeOp::Aggregate(agg_kind) => {
-                match agg_kind {
-                    AggKind::Adt(def_id) => {
-                        let agg_name = format!("{}::{{..}}", tcx.def_path_str(def_id));
-                        if is_marker {
-                            write!(attr, "label=\"Agg {}\" style=dashed ", escaped_string(agg_name)).unwrap();
-                        }
-                        else {
-                            write!(attr, "label=\"<f0> {:?} | <f1> Agg {}\" ", local, escaped_string(agg_name)).unwrap();
-                        }
-                    },
-                    _ => {
-                        if is_marker {
-                            write!(attr, "label=\"{:?}\" style=dashed ", agg_kind).unwrap();
-                        }
-                        else {
-                            write!(attr, "label=\"<f0> {:?} | {:?}\" ", local, agg_kind).unwrap();
-                        }
-                    }
-                }
-            }
-            _ => {
-                if is_marker {
-                    write!(attr, "label=\"<f1> {:?}\" style=dashed ", self.op).unwrap();
-                }
-                else {
-                    write!(attr, "label=\"<f0> {:?} | <f1> {:?}\" ", local, self.op).unwrap();
-                }
-            },
-        };
-        match color { //color=xxx
-            None => {},
-            Some(color) => {write!(attr, "color={} ", color).unwrap();},
-        }
-        write!(dot, "{:?} [{}]", local, attr).unwrap();
-        dot
     }
 }
 
@@ -342,33 +249,6 @@ impl Graph {
             }
             panic!("An error happened in add_terminator_to_graph.")
         }
-    }
-
-    pub fn to_dot_graph<'tcx>(&self, tcx: &TyCtxt<'tcx>) -> String {
-        let mut dot = String::new();
-        let name = tcx.def_path_str(self.def_id);
-
-        writeln!(dot, "digraph \"{}\" {{", &name).unwrap();
-        writeln!(dot, "    node [shape=record];").unwrap();
-        for (local, node) in self.nodes.iter_enumerated() {
-            let node_dot = if local <= Local::from_usize(self.argc) {
-                node.to_dot_graph(tcx, local, Some(String::from("red")), false)
-            }
-            else if local <= Local::from_usize(self.n_locals) {
-                node.to_dot_graph(tcx, local, None, false)
-            }
-            else {
-                node.to_dot_graph(tcx, local, None, true)
-            };
-            writeln!(dot, "    {}", node_dot).unwrap();
-        }
-        //edges
-        for edge in self.edges.iter() {
-            let edge_dot = edge.to_dot_graph();
-            writeln!(dot, "    {}", edge_dot).unwrap();
-        }
-        writeln!(dot, "}}").unwrap();
-        dot
     }
 
     pub fn collect_equivalent_locals(&self, local: Local) -> HashSet<Local> {

--- a/rap/src/analysis/utils.rs
+++ b/rap/src/analysis/utils.rs
@@ -1,1 +1,2 @@
 pub mod show_mir;
+pub mod def_path;

--- a/rap/src/analysis/utils/def_path.rs
+++ b/rap/src/analysis/utils/def_path.rs
@@ -1,0 +1,175 @@
+use rustc_middle::ty::TyCtxt;
+use rustc_hir::def::{DefKind, Res};
+use rustc_hir::def_id::{CrateNum, DefId, LocalDefId, LOCAL_CRATE};
+use rustc_hir::PrimTy;
+use rustc_span::symbol::{Ident, Symbol};
+use rustc_middle::ty::fast_reject::SimplifiedType;
+use rustc_hir::{ImplItemRef, ItemKind, Mutability, Node, OwnerId, TraitItemRef};
+use rustc_middle::ty::{FloatTy, IntTy, UintTy};
+
+pub fn def_path_last_def_id<'tcx>(tcx: &TyCtxt<'tcx>, path: &[&str]) -> DefId {
+    def_path_def_ids(tcx, path).last().unwrap()
+}
+
+
+// The code below refers to rust-clippy.
+
+/// Resolves a def path like `std::vec::Vec` to its [`DefId`]s, see [`def_path_res`].
+pub fn def_path_def_ids<'tcx>(tcx: &TyCtxt<'tcx>, path: &[&str]) -> impl Iterator<Item = DefId> {
+    def_path_res(tcx, path).into_iter().filter_map(|res| res.opt_def_id())
+}
+
+
+pub fn def_path_res<'tcx>(tcx: &TyCtxt<'tcx>, path: &[&str]) -> Vec<Res> {
+    let (base, mut path) = match *path {
+        [primitive] => {
+            return vec![PrimTy::from_name(Symbol::intern(primitive)).map_or(Res::Err, Res::PrimTy)];
+        },
+        [base, ref path @ ..] => (base, path),
+        _ => return Vec::new(),
+    };
+
+    let base_sym = Symbol::intern(base);
+
+    let local_crate = if tcx.crate_name(LOCAL_CRATE) == base_sym {
+        Some(LOCAL_CRATE.as_def_id())
+    } else {
+        None
+    };
+
+    let starts = find_primitive_impls(tcx, base)
+        .chain(tcx.crates(())
+            .iter()
+            .copied()
+            .filter(move |&num| tcx.crate_name(num) == base_sym)
+            .map(CrateNum::as_def_id)
+        )
+        .chain(local_crate)
+        .map(|id| Res::Def(tcx.def_kind(id), id));
+
+    let mut resolutions: Vec<Res> = starts.collect();
+
+    while let [segment, rest @ ..] = path {
+        path = rest;
+        let segment = Symbol::intern(segment);
+
+        resolutions = resolutions
+            .into_iter()
+            .filter_map(|res| res.opt_def_id())
+            .flat_map(|def_id| {
+                // When the current def_id is e.g. `struct S`, check the impl items in
+                // `impl S { ... }`
+                let inherent_impl_children = tcx
+                    .inherent_impls(def_id)
+                    .iter()
+                    .flat_map(|&impl_def_id| item_children_by_name(tcx, impl_def_id, segment));
+
+                let direct_children = item_children_by_name(tcx, def_id, segment);
+
+                inherent_impl_children.chain(direct_children)
+            })
+            .collect();
+    }
+
+    resolutions
+}
+
+fn find_primitive_impls<'tcx>(tcx: &TyCtxt<'tcx>, name: &str) -> impl Iterator<Item = DefId> + 'tcx {
+    let ty = match name {
+        "bool" => SimplifiedType::Bool,
+        "char" => SimplifiedType::Char,
+        "str" => SimplifiedType::Str,
+        "array" => SimplifiedType::Array,
+        "slice" => SimplifiedType::Slice,
+        // FIXME: rustdoc documents these two using just `pointer`.
+        //
+        // Maybe this is something we should do here too.
+        "const_ptr" => SimplifiedType::Ptr(Mutability::Not),
+        "mut_ptr" => SimplifiedType::Ptr(Mutability::Mut),
+        "isize" => SimplifiedType::Int(IntTy::Isize),
+        "i8" => SimplifiedType::Int(IntTy::I8),
+        "i16" => SimplifiedType::Int(IntTy::I16),
+        "i32" => SimplifiedType::Int(IntTy::I32),
+        "i64" => SimplifiedType::Int(IntTy::I64),
+        "i128" => SimplifiedType::Int(IntTy::I128),
+        "usize" => SimplifiedType::Uint(UintTy::Usize),
+        "u8" => SimplifiedType::Uint(UintTy::U8),
+        "u16" => SimplifiedType::Uint(UintTy::U16),
+        "u32" => SimplifiedType::Uint(UintTy::U32),
+        "u64" => SimplifiedType::Uint(UintTy::U64),
+        "u128" => SimplifiedType::Uint(UintTy::U128),
+        "f32" => SimplifiedType::Float(FloatTy::F32),
+        "f64" => SimplifiedType::Float(FloatTy::F64),
+        _ => return [].iter().copied(),
+    };
+
+    tcx.incoherent_impls(ty).iter().copied()
+}
+
+fn non_local_item_children_by_name<'tcx>(tcx: &TyCtxt<'tcx>, def_id: DefId, name: Symbol) -> Vec<Res> {
+    match tcx.def_kind(def_id) {
+        DefKind::Mod | DefKind::Enum | DefKind::Trait => tcx
+            .module_children(def_id)
+            .iter()
+            .filter(|item| item.ident.name == name)
+            .map(|child| child.res.expect_non_local())
+            .collect(),
+        DefKind::Impl { .. } => tcx
+            .associated_item_def_ids(def_id)
+            .iter()
+            .copied()
+            .filter(|assoc_def_id| tcx.item_name(*assoc_def_id) == name)
+            .map(|assoc_def_id| Res::Def(tcx.def_kind(assoc_def_id), assoc_def_id))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn local_item_children_by_name<'tcx>(tcx: &TyCtxt<'tcx>, local_id: LocalDefId, name: Symbol) -> Vec<Res> {
+    let hir = tcx.hir();
+
+    let root_mod;
+    let item_kind = match hir.find_by_def_id(local_id) {
+        Some(Node::Crate(r#mod)) => {
+            root_mod = ItemKind::Mod(r#mod);
+            &root_mod
+        },
+        Some(Node::Item(item)) => &item.kind,
+        _ => return Vec::new(),
+    };
+
+    let res = |ident: Ident, owner_id: OwnerId| {
+        if ident.name == name {
+            let def_id = owner_id.to_def_id();
+            Some(Res::Def(tcx.def_kind(def_id), def_id))
+        } else {
+            None
+        }
+    };
+
+    match item_kind {
+        ItemKind::Mod(r#mod) => r#mod
+            .item_ids
+            .iter()
+            .filter_map(|&item_id| res(hir.item(item_id).ident, item_id.owner_id))
+            .collect(),
+        ItemKind::Impl(r#impl) => r#impl
+            .items
+            .iter()
+            .filter_map(|&ImplItemRef { ident, id, .. }| res(ident, id.owner_id))
+            .collect(),
+        ItemKind::Trait(.., trait_item_refs) => trait_item_refs
+            .iter()
+            .filter_map(|&TraitItemRef { ident, id, .. }| res(ident, id.owner_id))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn item_children_by_name<'tcx>(tcx: &TyCtxt<'tcx>, def_id: DefId, name: Symbol) -> Vec<Res> {
+    if let Some(local_id) = def_id.as_local() {
+        local_item_children_by_name(tcx, local_id, name)
+    } else {
+        non_local_item_children_by_name(tcx, def_id, name)
+    }
+}


### PR DESCRIPTION
- add a function in `utils` to convert a def path(String) into its def id
  - the code refers to that of clippy
- fix bugs in graph building
  - the former version view a `Place` as a local, while more than one assignments can take place on a `Place`, thus we should identify them. this pr supports **a part of** variants of `Place`, and add virtual node markers in the graph
- correspondingly implement `to_dot_graph` functions
- refactor the code to extact the debug code together