### PR TITLE
fix: compiler error caused by missing of a statement

### DIFF
--- a/rap/src/analysis/core/dataflow.rs
+++ b/rap/src/analysis/core/dataflow.rs
@@ -1,4 +1,5 @@
 pub mod graph;
+pub mod debug;
 
 use std::collections::HashMap;
 use std::io::Write;


### PR DESCRIPTION
The previous pull request missed a statement to introduce the impls into the code.