### PR TITLE
Fix toolchain and CI, and update README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Rap-booting and testing
 
 on:
   push:
-    branches: [ "main", "fix-toolchain" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Rap-booting and testing
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "fix-toolchain" ]
   pull_request:
     branches: [ "main" ]
 

--- a/README.md
+++ b/README.md
@@ -13,15 +13,31 @@ cd RAP
 
 ## Usage
 
-Navigate to your Rust project folder containing a `Cargo.toml` file. If your project includes a `rust-toolchain.toml` file, we recommend disabling or removing it.
+Install `nightly-2024-06-30` on which rap is compiled with. This just needs to do once on your machine. If the toolchain exists,
+this will do nothing.
+
 ```shell
-cargo rap -help
+rustup toolchain install nightly-2024-06-30 --profile minimal --component rustc-dev,rust-src,llvm-tools-preview
+```
+
+Navigate to your Rust project folder containing a `Cargo.toml` file. Then run `cargo-rap` with [toolchain override shorthand syntax].
+
+[toolchain override shorthand syntax]: https://rust-lang.github.io/rustup/overrides.html#toolchain-override-shorthand
+
+```shell
+cargo +nightly-2024-06-30 rap # ... rest of options of cargo-rap
+```
+
+Check out supported options with `-help`:
+
+```shell
+cargo +nightly-2024-06-30 rap -help
 ```
 
 ### Use-After-Free Detection
 Detect bugs such as use-after-free and double free in Rust crates caused by unsafe code.
 ```shell
-cargo rap -uaf
+cargo +nightly-2024-06-30 rap -uaf
 ```
 
 If RAP gets stuck after executing `cargo clean`, try manually downloading metadata dependencies by running `cargo metadata`.
@@ -44,7 +60,7 @@ The feature is based on our SafeDrop paper, which was published in TOSEM.
 Detect memory leakage bugs caused by apis like [ManuallyDrop](https://doc.rust-lang.org/std/mem/struct.ManuallyDrop.html) and [into_raw()](https://doc.rust-lang.org/std/boxed/struct.Box.html#method.into_raw).
 
 ```shell
-cargo rap -mleak
+cargo +nightly-2024-06-30 rap -mleak
 ```
 
 The feature is based on our rCanary work, which was published in TSE

--- a/rap/rust-toolchain.toml
+++ b/rap/rust-toolchain.toml
@@ -2,4 +2,4 @@
 # The default version of the rustc compiler
 #channel = "nightly-2023-10-05-x86_64-unknown-linux-gnu"
 channel = "nightly-2024-06-30"
-components = ["rustc-dev", "rustc-src", "llvm-tools-preview"]
+components = ["rustc-dev", "rust-src", "llvm-tools-preview"]

--- a/rap/rust-toolchain.toml
+++ b/rap/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # The default version of the rustc compiler
 #channel = "nightly-2023-10-05-x86_64-unknown-linux-gnu"
-channel = "nightly-2024-06-30-x86_64-unknown-linux-gnu"
+channel = "nightly-2024-06-30"
 components = ["rustc-dev", "rustc-src", "llvm-tools-preview"]


### PR DESCRIPTION
This PR includes:
* stripping target triple from channel field (refer to https://rust-lang.github.io/rustup/overrides.html#channel )
* fixing a typo in component name
* updating actions/setup-python from v3 to v5
* updating README in usage with toolchain installation and override shorthand syntax