### PR TITLE
feat: support `RAP_LOG` environment variable; remove `-debug` option 

### DIFF
--- a/rap/Cargo.toml
+++ b/rap/Cargo.toml
@@ -33,3 +33,6 @@ colorful = "0.2.1"
 
 [features]
 backtraces = ["snafu/backtraces", "snafu/backtraces-impl-backtrace-crate"]
+
+[package.metadata.rust-analyzer]
+rustc_private = true

--- a/rap/src/bin/cargo-rap.rs
+++ b/rap/src/bin/cargo-rap.rs
@@ -3,7 +3,7 @@
     The file references the cargo file for Miri: https://github.com/rust-lang/miri/blob/master/cargo-miri/src/main.rs
 */
 use cargo_metadata::{Metadata, MetadataCommand};
-use rap::utils::log::{rap_error_and_exit, Verbosity};
+use rap::utils::log::{init_log, rap_error_and_exit};
 use rap::{rap_debug, rap_error, rap_info};
 use rustc_version::VersionMeta;
 use std::env;
@@ -35,7 +35,6 @@ General command:
     -V or -version:  show the version of RAP
 
 Debugging options:
-    -debug	         show the debug-level logs
     -mir             print the MIR of each function
 "#;
 
@@ -374,8 +373,9 @@ fn main() {
        2. Cargo check actually triggers `path/cargo-rap path/rustc` according to RUSTC_WRAPPER.
           Because RUSTC_WRAPPER is defined, Cargo calls the command: `$RUSTC_WRAPPER path/rustc ...`
     */
-    // Init the log_system; Use Verbosity::Debug for printing debugging messages.
-    Verbosity::init_log(Verbosity::Info).expect("Failed to init log.");
+
+    // Init the log_system
+    init_log().expect("Failed to init log.");
     rap_debug!("Enter cargo-rap; Received args: {:?}", env::args());
 
     let first_arg = env::args().nth(1);

--- a/rap/src/bin/rap.rs
+++ b/rap/src/bin/rap.rs
@@ -3,9 +3,7 @@
 extern crate rustc_driver;
 extern crate rustc_session;
 
-use rap::rap_debug;
-use rap::utils::log::Verbosity;
-use rap::{compile_time_sysroot, RapCallback, RAP_DEFAULT_ARGS};
+use rap::{compile_time_sysroot, rap_debug, utils::log::init_log, RapCallback, RAP_DEFAULT_ARGS};
 use rustc_session::config::ErrorOutputType;
 use rustc_session::EarlyDiagCtxt;
 use std::env;
@@ -35,7 +33,6 @@ fn run_complier(args: &mut Vec<String>, callback: &mut RapCallback) -> i32 {
 
 fn main() {
     // Parse the arguments from env.
-    let mut debug = false;
     let mut args = vec![];
     let mut compiler = RapCallback::default();
     for arg in env::args() {
@@ -52,18 +49,13 @@ fn main() {
             "-senryx" => compiler.enable_senryx(),
             "-callgraph" => compiler.enable_callgraph(),
             "-mir" => compiler.enable_show_mir(),
-            "-debug" => debug = true,
             "-adt" => {}
             "-z3" => {}
             "-meta" => {}
             _ => args.push(arg),
         }
     }
-    if debug == true {
-        Verbosity::init_log(Verbosity::Debug).expect("Failed to init debugging log");
-    } else {
-        Verbosity::init_log(Verbosity::Info).expect("Failed to init info log");
-    }
+    _ = init_log().inspect_err(|err| eprintln!("Failed to init log: {err}"));
     rap_debug!("rap received arguments{:#?}", env::args());
     rap_debug!("arguments to rustc: {:?}", &args);
 

--- a/rap/src/utils/log.rs
+++ b/rap/src/utils/log.rs
@@ -3,55 +3,54 @@ use fern::colors::{Color, ColoredLevelConfig};
 use fern::{self, Dispatch};
 use log::LevelFilter;
 
-#[derive(Debug, Copy, Clone, Hash)]
-pub enum Verbosity {
-    Info,
-    Debug,
-    Trace,
+fn log_level() -> LevelFilter {
+    if let Ok(s) = std::env::var("RAP_LOG") {
+        match s.parse() {
+            Ok(level) => return level,
+            Err(err) => eprintln!("RAP_LOG is invalid: {err}"),
+        }
+    }
+    LevelFilter::Info
 }
 
-impl Verbosity {
-    pub fn init_log(verbose: Verbosity) -> Result<(), fern::InitError> {
-        let mut dispatch = Dispatch::new();
-        let color_line = ColoredLevelConfig::new()
-            .info(Color::White)
-            .error(Color::Red)
-            .warn(Color::Yellow)
-            .debug(Color::White)
-            .trace(Color::BrightBlack);
+/// Detect `RAP_LOG` environment variable first; if it's not set,
+/// default to INFO level.
+pub fn init_log() -> Result<(), fern::InitError> {
+    let dispatch = Dispatch::new().level(log_level());
 
-        let color_level = color_line.info(Color::Green);
-        dispatch = match verbose {
-            Verbosity::Info => dispatch.level(LevelFilter::Info),
-            Verbosity::Debug => dispatch.level(LevelFilter::Debug),
-            Verbosity::Trace => dispatch.level(LevelFilter::Trace),
-        }; //.level_for("rap", LevelFilter::Debug);
+    let color_line = ColoredLevelConfig::new()
+        .info(Color::White)
+        .error(Color::Red)
+        .warn(Color::Yellow)
+        .debug(Color::White)
+        .trace(Color::BrightBlack);
 
-        let stderr_dispatch = Dispatch::new()
-            .format(move |callback, args, record| {
-                let time_now = Local::now();
-                callback.finish(format_args!(
-                    "{}{}:{}|RAP-FRONT|{}{}|: {}\x1B[0m",
-                    format_args!(
-                        "\x1B[{}m",
-                        color_line.get_color(&record.level()).to_fg_str()
-                    ),
-                    time_now.hour(),
-                    time_now.minute(),
-                    color_level.color(record.level()),
-                    format_args!(
-                        "\x1B[{}m",
-                        color_line.get_color(&record.level()).to_fg_str()
-                    ),
-                    args
-                ))
-            })
-            .chain(std::io::stderr());
+    let color_level = color_line.info(Color::Green);
 
-        /* Note that we cannot dispatch to stdout due to some bugs */
-        dispatch.chain(stderr_dispatch).apply()?;
-        Ok(())
-    }
+    let stderr_dispatch = Dispatch::new()
+        .format(move |callback, args, record| {
+            let time_now = Local::now();
+            callback.finish(format_args!(
+                "{}{}:{}|RAP-FRONT|{}{}|: {}\x1B[0m",
+                format_args!(
+                    "\x1B[{}m",
+                    color_line.get_color(&record.level()).to_fg_str()
+                ),
+                time_now.hour(),
+                time_now.minute(),
+                color_level.color(record.level()),
+                format_args!(
+                    "\x1B[{}m",
+                    color_line.get_color(&record.level()).to_fg_str()
+                ),
+                args
+            ))
+        })
+        .chain(std::io::stderr());
+
+    /* Note that we cannot dispatch to stdout due to some bugs */
+    dispatch.chain(stderr_dispatch).apply()?;
+    Ok(())
 }
 
 #[macro_export]


### PR DESCRIPTION
As discussed [here](https://github.com/Artisan-Lab/RAP/issues/53#issuecomment-2414036262), `RAP_LOG` is supported in this PR to dynamically set log level.

If RAP_LOG is not set, the default level is info as before.

I also remove -debug option because it'd be better to expose single way via RAP_LOG to set up the log level. The option now is equivalent to `RAP_LOG=DEBUG`.

The value on RAP_LOG is case-insensitive, which is defined in [LevelFilter::from_str](https://docs.rs/log/0.4.22/src/log/lib.rs.html#629-635).

`Verbosity` is also removed, because there is no reason to use it now.

Some tests:

* `cargo +nightly-2024-06-30 rap -F` and `RAP_LOG=WARN cargo +nightly-2024-06-30 rap -F`
![截图_20241016082628](https://github.com/user-attachments/assets/166b1bfb-5718-46f3-9efa-79451d31e839)

* `RAP_LOG=DEBUG cargo +nightly-2024-06-30 rap -F`
![截图_20241016082651](https://github.com/user-attachments/assets/b7efadd6-c8e8-4c18-8d04-54c178d4879f)


