### PR TITLE
feat: replace "RAP_FRONT" with "RAP"; use ISO 8601 timestamp in log

### DIFF
--- a/rap/src/utils/log.rs
+++ b/rap/src/utils/log.rs
@@ -1,4 +1,4 @@
-use chrono::Utc;
+use chrono::Local;
 use fern::colors::{Color, ColoredLevelConfig};
 use fern::{self, Dispatch};
 use log::LevelFilter;
@@ -26,17 +26,16 @@ pub fn init_log() -> Result<(), fern::InitError> {
         .trace(Color::BrightBlack);
 
     let color_level = color_line.info(Color::Green);
-
     let stderr_dispatch = Dispatch::new()
         .format(move |callback, args, record| {
-            let now = Utc::now();
+            let now = Local::now();
             callback.finish(format_args!(
                 "{}{}|RAP|{}{}|: {}\x1B[0m",
                 format_args!(
                     "\x1B[{}m",
                     color_line.get_color(&record.level()).to_fg_str()
                 ),
-                now.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+                now.format("%H:%M:%S%.3f").to_string(),
                 color_level.color(record.level()),
                 format_args!(
                     "\x1B[{}m",

--- a/rap/src/utils/log.rs
+++ b/rap/src/utils/log.rs
@@ -1,4 +1,4 @@
-use chrono::{Local, Timelike};
+use chrono::Utc;
 use fern::colors::{Color, ColoredLevelConfig};
 use fern::{self, Dispatch};
 use log::LevelFilter;
@@ -29,15 +29,14 @@ pub fn init_log() -> Result<(), fern::InitError> {
 
     let stderr_dispatch = Dispatch::new()
         .format(move |callback, args, record| {
-            let time_now = Local::now();
+            let now = Utc::now();
             callback.finish(format_args!(
-                "{}{}:{}|RAP-FRONT|{}{}|: {}\x1B[0m",
+                "{}{}|RAP|{}{}|: {}\x1B[0m",
                 format_args!(
                     "\x1B[{}m",
                     color_line.get_color(&record.level()).to_fg_str()
                 ),
-                time_now.hour(),
-                time_now.minute(),
+                now.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
                 color_level.color(record.level()),
                 format_args!(
                     "\x1B[{}m",


### PR DESCRIPTION
This PR changes log.rs to:
- replace "RAP_FRONT" with "RAP". Since RAP no longer has the concepts of "frontend" and "backend", there is no means to use "RAP_FRONT".
- use ISO 8601 timestamp for all logging. This facilitates the debugging and profiling of RAP. 

Below is an example of the new logging format:
![图片](https://github.com/user-attachments/assets/6536df4f-e074-498c-a97c-be9cdacddec6)
