### PR TITLE
Refactor alias module; Use HashSet to store RetAlias

### DIFF
--- a/rap/src/analysis/core/alias/mop.rs
+++ b/rap/src/analysis/core/alias/mop.rs
@@ -4,7 +4,7 @@ pub mod mop;
 pub mod types;
 
 use crate::analysis::core::alias::FnMap;
-use crate::rap_info;
+use crate::rap_debug;
 use crate::utils::source::*;
 use graph::MopGraph;
 use rustc_data_structures::fx::FxHashMap;
@@ -34,12 +34,12 @@ impl<'tcx> MopAlias<'tcx> {
                 self.query_mop(local_def_id.to_def_id());
             }
         }
-        rap_info!("Meaning of output: 0 for ret value; 1,2,3,... for corresponding args.");
+        // Meaning of output: 0 for ret value; 1,2,3,... for corresponding args.
         for (fn_id, fn_alias) in &self.fn_map {
             let fn_name = get_fn_name(self.tcx, *fn_id);
             if fn_alias.alias_vec.len() > 0 {
-                rap_info!("{:?},{:?}", fn_name, fn_id);
-                rap_info!("{}", fn_alias);
+                rap_debug!("{:?},{:?}", fn_name, fn_id);
+                rap_debug!("{}", fn_alias);
             }
         }
         return &self.fn_map;
@@ -47,7 +47,7 @@ impl<'tcx> MopAlias<'tcx> {
 
     pub fn query_mop(&mut self, def_id: DefId) -> () {
         let fn_name = get_fn_name(self.tcx, def_id);
-        rap_info!("query_mop: {:?}", fn_name);
+        rap_debug!("query_mop: {:?}", fn_name);
         /* filter const mir */
         if let Some(_other) = self.tcx.hir().body_const_context(def_id.expect_local()) {
             return;

--- a/rap/src/analysis/core/alias/mop.rs
+++ b/rap/src/analysis/core/alias/mop.rs
@@ -37,7 +37,7 @@ impl<'tcx> MopAlias<'tcx> {
         // Meaning of output: 0 for ret value; 1,2,3,... for corresponding args.
         for (fn_id, fn_alias) in &self.fn_map {
             let fn_name = get_fn_name(self.tcx, *fn_id);
-            if fn_alias.alias_vec.len() > 0 {
+            if fn_alias.len() > 0 {
                 rap_debug!("{:?},{:?}", fn_name, fn_id);
                 rap_debug!("{}", fn_alias);
             }

--- a/rap/src/analysis/core/alias/mop.rs
+++ b/rap/src/analysis/core/alias/mop.rs
@@ -22,7 +22,7 @@ pub struct MopAlias<'tcx> {
 impl<'tcx> MopAlias<'tcx> {
     pub fn new(tcx: TyCtxt<'tcx>) -> Self {
         Self {
-            tcx: tcx,
+            tcx,
             fn_map: FxHashMap::default(),
         }
     }
@@ -42,10 +42,10 @@ impl<'tcx> MopAlias<'tcx> {
                 rap_debug!("{}", fn_alias);
             }
         }
-        return &self.fn_map;
+        &self.fn_map
     }
 
-    pub fn query_mop(&mut self, def_id: DefId) -> () {
+    pub fn query_mop(&mut self, def_id: DefId) {
         let fn_name = get_fn_name(self.tcx, def_id);
         rap_debug!("query_mop: {:?}", fn_name);
         /* filter const mir */
@@ -58,11 +58,11 @@ impl<'tcx> MopAlias<'tcx> {
             mop_graph.solve_scc();
             let mut recursion_set = FxHashSet::default();
             mop_graph.check(0, &mut self.fn_map, &mut recursion_set);
-            if mop_graph.visit_times <= VISIT_LIMIT {
-                return;
-            } else {
-                println!("Over visited: {:?}", def_id);
+            if mop_graph.visit_times > VISIT_LIMIT {
+                rap_debug!("Over visited: {:?}", def_id);
             }
+        } else {
+            rap_debug!("mir is not available at {}", self.tcx.def_path_str(def_id));
         }
     }
 }

--- a/rap/src/analysis/core/alias/mop/alias.rs
+++ b/rap/src/analysis/core/alias/mop/alias.rs
@@ -89,7 +89,7 @@ impl<'tcx> MopGraph<'tcx> {
                                 //rap_info!("target_id {:?}", target_id);
                                 if fn_map.contains_key(&target_id) {
                                     let assignments = fn_map.get(&target_id).unwrap();
-                                    for assign in assignments.alias_vec.iter() {
+                                    for assign in assignments.aliases().iter() {
                                         if !assign.valuable() {
                                             continue;
                                         }
@@ -105,7 +105,7 @@ impl<'tcx> MopGraph<'tcx> {
                                     mop_graph.solve_scc();
                                     mop_graph.check(0, fn_map, recursion_set);
                                     let ret_alias = mop_graph.ret_alias.clone();
-                                    for assign in ret_alias.alias_vec.iter() {
+                                    for assign in ret_alias.aliases().iter() {
                                         if !assign.valuable() {
                                             continue;
                                         }
@@ -274,7 +274,7 @@ impl<'tcx> MopGraph<'tcx> {
                             );
                             new_alias.left_field_seq = self.get_field_seq(left_node);
                             new_alias.right_field_seq = self.get_field_seq(right_node);
-                            self.ret_alias.alias_vec.push(new_alias);
+                            self.ret_alias.add_alias(new_alias);
                         }
                     }
                 }

--- a/rap/src/analysis/core/alias/mop/mop.rs
+++ b/rap/src/analysis/core/alias/mop/mop.rs
@@ -55,7 +55,7 @@ impl<'tcx> MopGraph<'tcx> {
         self.alias_bbcall(self.scc_indices[bb_index], fn_map, recursion_set);
 
         /* Handle cases if the current block is a merged scc block with sub block */
-        if cur_block.scc_sub_blocks.len() > 0 {
+        if !cur_block.scc_sub_blocks.is_empty() {
             for i in cur_block.scc_sub_blocks.clone() {
                 self.alias_bb(i);
                 self.alias_bbcall(i, fn_map, recursion_set);
@@ -97,7 +97,7 @@ impl<'tcx> MopGraph<'tcx> {
             {
                 match discr {
                     Copy(p) | Move(p) => {
-                        let place = self.projection(false, p.clone());
+                        let place = self.projection(false, *p);
                         if let Some(constant) = self.constant.get(&self.values[place].alias[0]) {
                             single_target = true;
                             sw_val = *constant;
@@ -121,7 +121,7 @@ impl<'tcx> MopGraph<'tcx> {
                      * Filed 0 is the value; field 1 is the real target.
                      */
                     for iter in targets.iter() {
-                        if iter.0 as usize == sw_val as usize {
+                        if iter.0 as usize == sw_val {
                             sw_target = iter.1.as_usize();
                             break;
                         }

--- a/rap/src/analysis/safedrop/alias.rs
+++ b/rap/src/analysis/safedrop/alias.rs
@@ -91,7 +91,7 @@ impl<'tcx> SafeDropGraph<'tcx> {
                             if tcx.is_mir_available(*target_id) {
                                 if fn_map.contains_key(&target_id) {
                                     let assignments = fn_map.get(&target_id).unwrap();
-                                    for assign in assignments.alias_vec.iter() {
+                                    for assign in assignments.aliases().iter() {
                                         if !assign.valuable() {
                                             continue;
                                         }

--- a/rap/src/utils/log.rs
+++ b/rap/src/utils/log.rs
@@ -35,7 +35,7 @@ pub fn init_log() -> Result<(), fern::InitError> {
                     "\x1B[{}m",
                     color_line.get_color(&record.level()).to_fg_str()
                 ),
-                now.format("%H:%M:%S%.3f").to_string(),
+                now.format("%H:%M:%S"),
                 color_level.color(record.level()),
                 format_args!(
                     "\x1B[{}m",


### PR DESCRIPTION
This PR includes:
- feat: remove the millisecond format in the log. Now the date format in logging is %H:%M:%S".
- feat: change the log level from INFO to DEBUG in the alias module. Remove redundant logging messages.
- feat: use std::collections::HashSet to store RetAlias so we can prevent duplicate aliases from the result. 
- refactor: fix most of the cargo clippy warnings in the alias module.