### PR TITLE
Add a simple alignment check in senryx

### DIFF
--- a/rap/src/analysis/senryx.rs
+++ b/rap/src/analysis/senryx.rs
@@ -12,11 +12,12 @@ use visitor::BodyVisitor;
 
 pub struct SenryxCheck<'tcx> {
     pub tcx: TyCtxt<'tcx>,
+    pub threshhold: usize,
 }
 
 impl<'tcx> SenryxCheck<'tcx> {
-    pub fn new(tcx: TyCtxt<'tcx>) -> Self {
-        Self { tcx }
+    pub fn new(tcx: TyCtxt<'tcx>, threshhold: usize) -> Self {
+        Self { tcx, threshhold }
     }
 
     pub fn start(&self) {

--- a/rap/src/analysis/senryx/contracts/abstract_state.rs
+++ b/rap/src/analysis/senryx/contracts/abstract_state.rs
@@ -57,8 +57,8 @@ pub enum InitState {
 
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
 pub enum VType {
-    Pointer(usize,usize), // (align, size)
-    // todo
+    Pointer(usize, usize), // (align, size)
+                           // todo
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -70,7 +70,11 @@ pub struct AbstractStateItem {
 
 impl AbstractStateItem {
     pub fn new(value: (Value, Value), vtype: VType, state: HashSet<StateType>) -> Self {
-        Self { value, vtype, state }
+        Self {
+            value,
+            vtype,
+            state,
+        }
     }
 
     pub fn meet_state_item(&mut self, other_state: &AbstractStateItem) {

--- a/rap/src/analysis/senryx/contracts/abstract_state.rs
+++ b/rap/src/analysis/senryx/contracts/abstract_state.rs
@@ -11,6 +11,7 @@ pub enum Value {
     Isize(isize),
     U32(u32),
     Custom(),
+    None,
     // ...
 }
 
@@ -54,15 +55,22 @@ pub enum InitState {
     PartlyInitialized,
 }
 
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
+pub enum VType {
+    Pointer(usize,usize), // (align, size)
+    // todo
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct AbstractStateItem {
     pub value: (Value, Value),
+    pub vtype: VType,
     pub state: HashSet<StateType>,
 }
 
 impl AbstractStateItem {
-    pub fn new(value: (Value, Value), state: HashSet<StateType>) -> Self {
-        Self { value, state }
+    pub fn new(value: (Value, Value), vtype: VType, state: HashSet<StateType>) -> Self {
+        Self { value, vtype, state }
     }
 
     pub fn meet_state_item(&mut self, other_state: &AbstractStateItem) {

--- a/rap/src/analysis/senryx/contracts/checker.rs
+++ b/rap/src/analysis/senryx/contracts/checker.rs
@@ -25,13 +25,13 @@ impl<T> SliceFromRawPartsChecker<T> {
         map.insert(
             0,
             vec![
-                Contract::ValueCheck {
+                Contract::StateCheck {
                     op: Op::GE,
-                    value: Value::Usize(0),
+                    state: StateType::AllocatedState(AllocatedState::Alloc),
                 },
                 Contract::StateCheck {
-                    op: Op::EQ,
-                    state: StateType::AllocatedState(AllocatedState::Alloc),
+                    op: Op::NE,
+                    state: StateType::AlignState(AlignState::Small2BigCast),
                 },
             ],
         );

--- a/rap/src/analysis/senryx/matcher.rs
+++ b/rap/src/analysis/senryx/matcher.rs
@@ -16,7 +16,7 @@ pub fn match_unsafe_api_and_check_contracts<T>(
     let base_func_name = func_name.split::<&str>("<").next().unwrap_or(func_name);
     // println!("base name ---- {:?}",base_func_name);
     let checker: Option<Box<dyn Checker>> = match base_func_name {
-        "std::slice::from_raw_parts::" => Some(Box::new(SliceFromRawPartsChecker::<T>::new())),
+        "std::slice::from_raw_parts::" | "std::slice::from_raw_parts_mut::" => Some(Box::new(SliceFromRawPartsChecker::<T>::new())),
         _ => None,
     };
 
@@ -34,7 +34,9 @@ fn process_checker(checker: &dyn Checker, args: &Box<[Spanned<Operand>]>, abstat
             }
             if let Some(abstate_item) = abstate.state_map.get(&arg_place) {
                 if !check_contract(*contract, abstate_item) {
-                    println!("Checking contract failed! ---- {:?}", contract);
+                    println!("Contract failed! ---- {:?}", contract);
+                } else {
+                    println!("Contract passed! ---- {:?}", contract);
                 }
             }
         }

--- a/rap/src/analysis/senryx/matcher.rs
+++ b/rap/src/analysis/senryx/matcher.rs
@@ -41,7 +41,6 @@ fn process_checker(checker: &dyn Checker, args: &Box<[Spanned<Operand>]>, abstat
     }
 }
 
-
 pub fn get_arg_place(arg: &Operand) -> usize {
     match arg {
         Operand::Move(place) => place.local.as_usize(),

--- a/rap/src/analysis/senryx/matcher.rs
+++ b/rap/src/analysis/senryx/matcher.rs
@@ -1,13 +1,14 @@
 use rustc_middle::mir::Operand;
 use rustc_span::source_map::Spanned;
 
+use crate::rap_warn;
+
 use super::contracts::{
     abstract_state::AbstractState,
     checker::{Checker, SliceFromRawPartsChecker},
     contract::check_contract,
 };
 
-//pub fn match_unsafe_api_and_check_contracts<T>(func_name: &str, args:&Vec<Operand>, abstate:&AbstractState, _ty: T) {
 pub fn match_unsafe_api_and_check_contracts<T>(
     func_name: &str,
     args: &Box<[Spanned<Operand>]>,
@@ -26,7 +27,6 @@ pub fn match_unsafe_api_and_check_contracts<T>(
     }
 }
 
-//fn process_checker(checker: &dyn Checker, args: &Vec<Operand>, abstate: &AbstractState) {
 fn process_checker(checker: &dyn Checker, args: &Box<[Spanned<Operand>]>, abstate: &AbstractState) {
     for (idx, contracts_vec) in checker.variable_contracts().iter() {
         for contract in contracts_vec {
@@ -40,6 +40,16 @@ fn process_checker(checker: &dyn Checker, args: &Box<[Spanned<Operand>]>, abstat
                 }
             }
         }
+    }
+}
+
+// level: 0 bug_level, 1-3 unsound_level
+// TODO: add more information about the result
+pub fn output_results(level:usize, threshold: usize) {
+    if level == 0{
+        rap_warn!("Find one bug!")
+    } else if level <= threshold {
+        rap_warn!("Find an unsoundness issue!")
     }
 }
 

--- a/rap/src/analysis/senryx/matcher.rs
+++ b/rap/src/analysis/senryx/matcher.rs
@@ -16,7 +16,9 @@ pub fn match_unsafe_api_and_check_contracts<T>(
     let base_func_name = func_name.split::<&str>("<").next().unwrap_or(func_name);
     // println!("base name ---- {:?}",base_func_name);
     let checker: Option<Box<dyn Checker>> = match base_func_name {
-        "std::slice::from_raw_parts::" | "std::slice::from_raw_parts_mut::" => Some(Box::new(SliceFromRawPartsChecker::<T>::new())),
+        "std::slice::from_raw_parts::" | "std::slice::from_raw_parts_mut::" => {
+            Some(Box::new(SliceFromRawPartsChecker::<T>::new()))
+        }
         _ => None,
     };
 

--- a/rap/src/analysis/senryx/matcher.rs
+++ b/rap/src/analysis/senryx/matcher.rs
@@ -1,8 +1,6 @@
 use rustc_middle::mir::Operand;
 use rustc_span::source_map::Spanned;
 
-use crate::rap_warn;
-
 use super::contracts::{
     abstract_state::AbstractState,
     checker::{Checker, SliceFromRawPartsChecker},
@@ -43,15 +41,6 @@ fn process_checker(checker: &dyn Checker, args: &Box<[Spanned<Operand>]>, abstat
     }
 }
 
-// level: 0 bug_level, 1-3 unsound_level
-// TODO: add more information about the result
-pub fn output_results(level:usize, threshold: usize) {
-    if level == 0{
-        rap_warn!("Find one bug!")
-    } else if level <= threshold {
-        rap_warn!("Find an unsoundness issue!")
-    }
-}
 
 pub fn get_arg_place(arg: &Operand) -> usize {
     match arg {

--- a/rap/src/lib.rs
+++ b/rap/src/lib.rs
@@ -224,7 +224,7 @@ pub fn start_analyzer(tcx: TyCtxt, callback: RapCallback) {
     }
 
     if callback.is_senryx_enabled() {
-        SenryxCheck::new(tcx).start();
+        SenryxCheck::new(tcx, 2).start();
     }
 
     if callback.is_callgraph_enabled() {

--- a/tests/senryx_tests/slice_from_raw_parts/src/main.rs
+++ b/tests/senryx_tests/slice_from_raw_parts/src/main.rs
@@ -1,19 +1,31 @@
 use std::slice;
 
-fn test1() {
-    let data: *const u8 = Box::leak(Box::new(0));
-    let len: usize = (isize::MAX as usize) / std::mem::size_of::<u8>() + 1;
-    // Pass(Allocated \ Aligned):   data is allocated and aligned
-    // Fail(Bounded): 'len' is out of the max value
-    // Fail(Dereferencable \ Initialized): 'data' onnly points to the memory with a 'u8' size, but the 'len' is out of this range
-    let slice: &[u8] = unsafe { slice::from_raw_parts(data, len) };
-    if let Some(last_element) = slice.last() {
-        println!("Last element: {}", last_element);
-    } else {
-        println!("Slice is empty");
+// fn test1() {
+//     let data: *const u8 = Box::leak(Box::new(0));
+//     let len: usize = (isize::MAX as usize) / std::mem::size_of::<u8>() + 1;
+//     // Pass(Allocated \ Aligned):   data is allocated and aligned
+//     // Fail(Bounded): 'len' is out of the max value
+//     // Fail(Dereferencable \ Initialized): 'data' onnly points to the memory with a 'u8' size, but the 'len' is out of this range
+//     let slice: &[u8] = unsafe { slice::from_raw_parts(data, len) };
+//     if let Some(last_element) = slice.last() {
+//         println!("Last element: {}", last_element);
+//     } else {
+//         println!("Slice is empty");
+//     }
+// }
+
+fn test2(a: &mut [u8], b: &[u32; 20]) {
+    unsafe {
+        let c = slice::from_raw_parts_mut(a.as_mut_ptr() as *mut u32, 20);
+        for i in 0..20 {
+            c[i] ^= b[i];
+        }
     }
 }
 
 fn main() {
-    test1();
+    // test1();
+    let mut x = [0u8;40];
+    let y = [0u32;20];
+    test2(&mut x[1..32], &y);
 }


### PR DESCRIPTION
This pr:

1. Add the basic align check module, which tracks the abstract state based on the rvalue of the pointer type and checks for the presence of small to big casts
2. Use CVE's classic align issue as a test case, now you can:
`cd tests/senryx_tests/slice_from_raw_parts/`
Then run `cargo rap -senryx` to get an initial version of the output.

Other unsafe apis and program status are tracked and developed based on this demo in the future.