### PR TITLE
fix: replace is_crate_type_lib by filter_crate_type to support extra crate-types

### DIFF
--- a/rap/src/bin/cargo-rap/args.rs
+++ b/rap/src/bin/cargo-rap/args.rs
@@ -90,10 +90,17 @@ pub fn is_current_compile_crate() -> bool {
     ARGS.is_current_compile_crate()
 }
 
-pub fn is_crate_type_lib() -> bool {
-    get_arg_flag_value("--crate-type")
-        .map(|s| s == "lib" || s == "rlib" || s == "staticlib")
-        .unwrap_or(false)
+/// Returns true for crate types to be checked;
+/// returns false for some special crate types that can't be handled by rap.
+/// For example, skip build.rs which causes linking errors in rap.
+pub fn filter_crate_type() -> bool {
+    if let Some(s) = get_arg_flag_value("--crate-type") {
+        if s == "bin" && get_arg_flag_value("--crate-name") == Some("build_script_build") {
+            return false;
+        }
+    }
+    // NOTE: tests doesn't have --crate-type, they are handled with --test by rustc
+    return true;
 }
 
 pub fn get_arg(pos: usize) -> Option<&'static str> {

--- a/rap/src/bin/cargo-rap/args.rs
+++ b/rap/src/bin/cargo-rap/args.rs
@@ -99,7 +99,7 @@ pub fn filter_crate_type() -> bool {
             return false;
         }
     }
-    // NOTE: tests doesn't have --crate-type, they are handled with --test by rustc
+    // NOTE: tests don't have --crate-type, they are handled with --test by rustc
     return true;
 }
 

--- a/rap/src/bin/cargo-rap/main.rs
+++ b/rap/src/bin/cargo-rap/main.rs
@@ -45,12 +45,12 @@ fn phase_rustc_wrapper() {
 
     let is_direct = args::is_current_compile_crate();
     // rap only checks local crates
-    if is_direct && args::is_crate_type_lib() {
+    if is_direct && args::filter_crate_type() {
         run_rap();
         return;
     }
 
-    // for dependencies, run rustc as usual
+    // for dependencies and some special crate types, run rustc as usual
     run_rustc();
 }
 


### PR DESCRIPTION


so far, the following usages on cargo-rap are tested:

```bash
export RAP_LOG=warn

# os-checker-test-suite/workspace2
# cargo rap -F -M -- -p # list Possible packages/workspace members
cargo rap -F -M -- -p ws-rap-checks-this1
cargo rap -F -M -- -p ws-rap-checks-this2
cargo rap -F -M -- --workspace

# check with feature selection
cargo rap -F -M -- -p ws-rap-checks-this_with-feature-gated -F rap

# check packages (build.rs is not detected by rap, but directly handled by rustc)
cargo rap -F -M -- -p ws-rap-checks-this_with-build-script

# check tests & examples
cargo rap -F -M -- -p ws-rap-checks-test-and-example --examples --tests
cd crates/ws-rap-checks-test-and-example
cargo rap -F -M -- --example ex1
cargo rap -F -M -- --examples
cargo rap -F -M -- --tests
cargo rap -F -M -- --examples --tests
```

see https://github.com/os-checker/os-checker-test-suite/tree/main/workspace2