### PR TITLE
fix: ignore proc-macro crates in rap

### DIFF
--- a/rap/Cargo.lock
+++ b/rap/Cargo.lock
@@ -375,6 +375,7 @@ dependencies = [
  "chrono",
  "colorful",
  "fern",
+ "lazy_static",
  "log",
  "regex",
  "rustc-demangle",

--- a/rap/src/bin/cargo-rap/args.rs
+++ b/rap/src/bin/cargo-rap/args.rs
@@ -92,9 +92,12 @@ pub fn is_current_compile_crate() -> bool {
 
 /// Returns true for crate types to be checked;
 /// returns false for some special crate types that can't be handled by rap.
-/// For example, skip build.rs which causes linking errors in rap.
+/// For example, checking proc-macro crates or build.rs can cause linking errors in rap.
 pub fn filter_crate_type() -> bool {
     if let Some(s) = get_arg_flag_value("--crate-type") {
+        if s == "proc-macro" {
+            return false;
+        }
         if s == "bin" && get_arg_flag_value("--crate-name") == Some("build_script_build") {
             return false;
         }

--- a/rap/src/bin/cargo-rap/cargo_check.rs
+++ b/rap/src/bin/cargo-rap/cargo_check.rs
@@ -3,7 +3,7 @@ use rap::utils::log::rap_error_and_exit;
 use std::{process::Command, time::Duration};
 use wait_timeout::ChildExt;
 
-pub fn run_cargo_check() {
+pub fn run() {
     let [rap_args, cargo_args] = crate::args::rap_and_cargo_args();
     rap_debug!("rap_args={rap_args:?}\tcargo_args={cargo_args:?}");
 

--- a/rap/src/bin/cargo-rap/main.rs
+++ b/rap/src/bin/cargo-rap/main.rs
@@ -14,8 +14,7 @@ mod help;
 mod utils;
 use crate::utils::*;
 
-mod target;
-use target::*;
+mod cargo_check;
 
 fn phase_cargo_rap() {
     rap_info!("Start cargo-rap");
@@ -37,7 +36,7 @@ fn phase_cargo_rap() {
         _ => {}
     }
 
-    run_cargo_check();
+    cargo_check::run();
 }
 
 fn phase_rustc_wrapper() {


### PR DESCRIPTION
Checking proc macro crates will raise cc errors. So directly pass it to rustc instead of to rap.

For tokio:

before:

<img width="1373" alt="f95672ff26e386d8e1a91f3d4b5204c" src="https://github.com/user-attachments/assets/f5406bd4-f8a3-420b-b98e-10fcd7b54b87">

after:

![截图_20241112201534](https://github.com/user-attachments/assets/34301400-69e1-47c4-a601-b89baf47a47e)
