### PR TITLE
feaf: introduce `RAP_RECURSIVE` to check packages recursively and `RAP_CLEAN` to run cargo clean before check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
     branches: [ "main" ]
 
 env:
-  RUSTUP_TOOLCHAIN: nightly-2024-06-30
   CARGO_TERM_COLOR: always
   RAP_RECURSIVE: true
 
@@ -37,7 +36,7 @@ jobs:
         ./install.sh
 
     - name: Check test cases 
-      run: cd tests && cargo rap -F -M
+      run: cd tests && cargo rap +nightly-2024-06-30 -F -M
 
     - name: Check rap
-      run: cd rap && cargo rap -F -M
+      run: cd rap && cargo rap +nightly-2024-06-30 -F -M

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,9 @@ on:
     branches: [ "main" ]
 
 env:
+  RUSTUP_TOOLCHAIN: nightly-2024-06-30
   CARGO_TERM_COLOR: always
+  RAP_RECURSIVE: true
 
 jobs:
   build:
@@ -34,7 +36,8 @@ jobs:
         chmod +x ./install.sh
         ./install.sh
 
-    - name: Run Test
-      run: |
-        cd tests
-        RAP_RECURSIVE=deep cargo +nightly-2024-06-30 rap -F -M
+    - name: Check test cases 
+      run: cd tests && cargo rap -F -M
+
+    - name: Check rap
+      run: cd rap && cargo rap -F -M

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,3 +33,8 @@ jobs:
       run: |
         chmod +x ./install.sh
         ./install.sh
+
+    - name: Run Test
+      run: |
+        cd tests
+        RAP_RECURSIVE=deep cargo +nightly-2024-06-30 rap -F -M

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         ./install.sh
 
     - name: Check test cases 
-      run: cd tests && cargo rap +nightly-2024-06-30 -F -M
+      run: cd tests && cargo +nightly-2024-06-30 rap -F -M
 
     - name: Check rap
-      run: cd rap && cargo rap +nightly-2024-06-30 -F -M
+      run: cd rap && cargo +nightly-2024-06-30 rap -F -M

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RAP_RECURSIVE: true
+  RAP_RECURSIVE: deep
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -48,17 +48,18 @@ cargo +nightly-2024-06-30 rap -help
 
 Environment variables (Values are case insensitive):
 
-| var             | default when absent | one of these values | description                |
-|-----------------|---------------------|---------------------|----------------------------|
-| `RAP_LOG`       | info                | debug, info, warn   | verbosity of logging       |
-| `RAP_RECURSIVE` | none                | none, shallow, deep | scope of packages to check |
+| var             | default when absent | one of these values | description                  |
+|-----------------|---------------------|---------------------|------------------------------|
+| `RAP_LOG`       | info                | debug, info, warn   | verbosity of logging         |
+| `RAP_CLEAN`     | true                | ture, false         | run cargo clean before check |
+| `RAP_RECURSIVE` | none                | none, shallow, deep | scope of packages to check   |
 
 For `RAP_RECURSIVE`:
 * none: check for current folder
 * shallow: check for current workpace members
 * deep: check for all workspaces from current folder
  
-NOTE: for shallow or deep, rap will clean the workspace target folder and enter each member to do the check.
+NOTE: for shallow or deep, rap will enter each member folder to do the check.
 
 ### Use-After-Free Detection
 Detect bugs such as use-after-free and double free in Rust crates caused by unsafe code.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ Check out supported options with `-help`:
 cargo +nightly-2024-06-30 rap -help
 ```
 
+Environment variables (Values are case insensitive):
+
+| var             | default when absent | one of these values | description                |
+|-----------------|---------------------|---------------------|----------------------------|
+| `RAP_LOG`       | info                | debug, info, warn   | verbosity of logging       |
+| `RAP_RECURSIVE` | none                | none, shallow, deep | scope of packages to check |
+
+For `RAP_RECURSIVE`:
+* none: check for current folder
+* shallow: check for current workpace members
+* deep: check for all workspaces from current folder
+ 
+NOTE: for shallow or deep, rap will clean the workspace target folder and enter each member to do the check.
+
 ### Use-After-Free Detection
 Detect bugs such as use-after-free and double free in Rust crates caused by unsafe code.
 ```shell

--- a/rap/Cargo.lock
+++ b/rap/Cargo.lock
@@ -79,7 +79,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.37",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -93,6 +93,38 @@ name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "camino"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "cc"
@@ -352,18 +384,18 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -372,6 +404,7 @@ dependencies = [
 name = "rap"
 version = "1.0.0"
 dependencies = [
+ "cargo_metadata",
  "chrono",
  "colorful",
  "fern",
@@ -382,6 +415,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "wait-timeout",
+ "walkdir",
  "z3",
 ]
 
@@ -433,23 +467,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
-name = "serde"
-version = "1.0.188"
+name = "same-file"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.215"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -505,13 +557,33 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.37"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -527,6 +599,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -550,7 +632,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -572,7 +654,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -598,6 +680,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/rap/Cargo.toml
+++ b/rap/Cargo.toml
@@ -27,8 +27,9 @@ fern = {version = "0.6.2", features = ["colored"]}
 wait-timeout = "0.2.0"
 rustc-demangle = "0.1.21"
 colorful = "0.2.1"
-#stopwatch = "0.0.7"
 regex = "1.11.1"
+walkdir = "2"
+cargo_metadata  = "0.18"
 
 [features]
 backtraces = ["snafu/backtraces", "snafu/backtraces-impl-backtrace-crate"]

--- a/rap/src/bin/cargo-rap/args.rs
+++ b/rap/src/bin/cargo-rap/args.rs
@@ -12,6 +12,7 @@ struct Arguments {
     /// options as second half after -- in args
     args_group2: Vec<String>,
     current_exe_path: PathBuf,
+    rap_clean: bool,
 }
 
 impl Arguments {
@@ -39,15 +40,28 @@ impl Arguments {
     }
 
     fn new() -> Self {
+        fn rap_clean() -> bool {
+            match env::var("RAP_CLEAN")
+                .ok()
+                .map(|s| s.trim().to_ascii_lowercase())
+                .as_deref()
+            {
+                Some("false") => false,
+                _ => true, // clean is the preferred behavior
+            }
+        }
+
         let args: Vec<_> = env::args().collect();
         let path = env::current_exe().expect("Current executable path invalid.");
         rap_debug!("Current exe: {path:?}\tReceived args: {args:?}");
         let [args_group1, args_group2] = split_args_by_double_dash(&args);
+
         Arguments {
             args,
             args_group1,
             args_group2,
             current_exe_path: path,
+            rap_clean: rap_clean(),
         }
     }
 
@@ -62,6 +76,10 @@ impl Arguments {
         };
         entry_path.is_relative()
     }
+}
+
+pub fn rap_clean() -> bool {
+    ARGS.rap_clean
 }
 
 fn split_args_by_double_dash(args: &[String]) -> [Vec<String>; 2] {

--- a/rap/src/bin/cargo-rap/args.rs
+++ b/rap/src/bin/cargo-rap/args.rs
@@ -95,15 +95,14 @@ pub fn is_current_compile_crate() -> bool {
 /// For example, checking proc-macro crates or build.rs can cause linking errors in rap.
 pub fn filter_crate_type() -> bool {
     if let Some(s) = get_arg_flag_value("--crate-type") {
-        if s == "proc-macro" {
-            return false;
-        }
-        if s == "bin" && get_arg_flag_value("--crate-name") == Some("build_script_build") {
-            return false;
-        }
+        return match s {
+            "proc-macro" => false,
+            "bin" if get_arg_flag_value("--crate-name") == Some("build_script_build") => false,
+            _ => true,
+        };
     }
-    // NOTE: tests don't have --crate-type, they are handled with --test by rustc
-    return true;
+    // NOTE: tests don't have --crate-type, they are handled with --test by rustc.
+    true
 }
 
 pub fn get_arg(pos: usize) -> Option<&'static str> {

--- a/rap/src/bin/cargo-rap/cargo_check.rs
+++ b/rap/src/bin/cargo-rap/cargo_check.rs
@@ -7,7 +7,7 @@ use rap::utils::log::rap_error_and_exit;
 use std::{collections::BTreeMap, process::Command, time::Duration};
 use wait_timeout::ChildExt;
 
-pub fn run(dir: &Utf8Path) {
+fn run(dir: &Utf8Path) {
     let [rap_args, cargo_args] = args::rap_and_cargo_args();
     rap_debug!("rap_args={rap_args:?}\tcargo_args={cargo_args:?}");
 
@@ -52,36 +52,20 @@ pub fn run(dir: &Utf8Path) {
     };
 }
 
-pub fn get_cargo_tomls_deep_recursively(dir: &str) -> Vec<Utf8PathBuf> {
-    walkdir::WalkDir::new(dir)
-        .into_iter()
-        .filter_map(|entry| {
-            if let Ok(e) = entry {
-                if e.file_type().is_file() && e.file_name().to_str()? == "Cargo.toml" {
-                    let path = Utf8PathBuf::from_path_buf(e.into_path());
-                    return path.ok()?.canonicalize_utf8().ok();
-                }
-            }
-            None
-        })
-        .collect()
+/// Just like running a cargo check in a folder.
+pub fn default_run() {
+    run(".".into());
+}
+
+/// Run cargo check in each member folder under current workspace.
+pub fn shallow_run() {
+    let ws_metadata = workspace(".".into());
+    for pkg_folder in get_member_folders(&ws_metadata) {
+        run(pkg_folder);
+    }
 }
 
 type Workspaces = BTreeMap<Utf8PathBuf, Metadata>;
-
-fn workspaces(cargo_tomls: &[Utf8PathBuf]) -> Workspaces {
-    let mut map = BTreeMap::new();
-    for cargo_toml in cargo_tomls {
-        let metadata = workspace(cargo_toml);
-        let root = &metadata.workspace_root;
-        // 每个 member package 解析的 workspace_root 和 members 是一样的
-        if !map.contains_key(root) {
-            map.insert(root.clone(), metadata);
-        }
-    }
-
-    map
-}
 
 fn workspace(cargo_toml: &Utf8Path) -> Metadata {
     let exec = cargo_metadata::MetadataCommand::new()
@@ -107,19 +91,6 @@ fn get_member_folders(meta: &Metadata) -> Vec<&Utf8Path> {
         .collect()
 }
 
-/// Just like running a cargo check in a folder.
-pub fn default_run() {
-    run(".".into());
-}
-
-/// Run cargo check in each member folder under current workspace.
-pub fn shallow_run() {
-    let metadata = workspace(".".into());
-    for pkg_folder in get_member_folders(&metadata) {
-        run(pkg_folder);
-    }
-}
-
 /// Recursively run cargo check in each package folder from current folder.
 pub fn deep_run() {
     let cargo_tomls = get_cargo_tomls_deep_recursively(".");
@@ -128,4 +99,33 @@ pub fn deep_run() {
             run(pkg_folder);
         }
     }
+}
+
+fn get_cargo_tomls_deep_recursively(dir: &str) -> Vec<Utf8PathBuf> {
+    walkdir::WalkDir::new(dir)
+        .into_iter()
+        .filter_map(|entry| {
+            if let Ok(e) = entry {
+                if e.file_type().is_file() && e.file_name().to_str()? == "Cargo.toml" {
+                    let path = Utf8PathBuf::from_path_buf(e.into_path());
+                    return path.ok()?.canonicalize_utf8().ok();
+                }
+            }
+            None
+        })
+        .collect()
+}
+
+fn workspaces(cargo_tomls: &[Utf8PathBuf]) -> Workspaces {
+    let mut map = BTreeMap::new();
+    for cargo_toml in cargo_tomls {
+        let metadata = workspace(cargo_toml);
+        let root = &metadata.workspace_root;
+        // 每个 member package 解析的 workspace_root 和 members 是一样的
+        if !map.contains_key(root) {
+            map.insert(root.clone(), metadata);
+        }
+    }
+
+    map
 }

--- a/rap/src/bin/cargo-rap/cargo_check.rs
+++ b/rap/src/bin/cargo-rap/cargo_check.rs
@@ -7,12 +7,13 @@ use rap::utils::log::rap_error_and_exit;
 use std::{collections::BTreeMap, process::Command, time::Duration};
 use wait_timeout::ChildExt;
 
-pub fn run() {
+pub fn run<'a>(dir: impl Into<&'a Utf8Path>) {
     let [rap_args, cargo_args] = args::rap_and_cargo_args();
     rap_debug!("rap_args={rap_args:?}\tcargo_args={cargo_args:?}");
 
     /*Here we prepare the cargo command as cargo check, which is similar to build, but much faster*/
     let mut cmd = Command::new("cargo");
+    cmd.current_dir(dir.into());
     cmd.arg("check");
 
     /* set the target as a filter for phase_rustc_rap */
@@ -89,4 +90,9 @@ fn workspaces(cargo_tomls: &[Utf8PathBuf]) -> Workspaces {
     }
 
     map
+}
+
+/// Just like running a cargo check in a folder.
+pub fn default_run() {
+    run(".");
 }

--- a/rap/src/bin/cargo-rap/cargo_check.rs
+++ b/rap/src/bin/cargo-rap/cargo_check.rs
@@ -23,6 +23,7 @@ pub fn run() {
 
 fn cargo_check(dir: &Utf8Path) {
     // always clean before check due to outdated except `RAP_CLEAN` is false
+    rap_info!("cargo clean in package folder {dir}");
     cargo_clean(dir, args::rap_clean());
 
     rap_info!("cargo check in package folder {dir}");
@@ -72,7 +73,6 @@ fn cargo_check(dir: &Utf8Path) {
 
 fn cargo_clean(dir: &Utf8Path, really: bool) {
     if really {
-        rap_info!("cargo clean in workspace root {dir}");
         if let Err(err) = Command::new("cargo").arg("clean").current_dir(dir).output() {
             rap_error_and_exit(format!("`cargo clean` exits unexpectedly:\n{err}"));
         }

--- a/rap/src/bin/cargo-rap/cargo_check/workspace.rs
+++ b/rap/src/bin/cargo-rap/cargo_check/workspace.rs
@@ -1,0 +1,98 @@
+use cargo_metadata::{
+    camino::{Utf8Path, Utf8PathBuf},
+    Metadata,
+};
+use rap::utils::log::rap_error_and_exit;
+use std::{collections::BTreeMap, process::Command};
+
+/// Run cargo check in each member folder under current workspace.
+pub fn shallow_run() {
+    let cargo_toml = Utf8Path::new("Cargo.toml");
+    if !cargo_toml.exists() {
+        rap_error_and_exit("rap should be run in a folder directly containing Cargo.toml");
+    }
+    let ws_metadata = workspace(cargo_toml);
+    clean_and_check(&ws_metadata);
+}
+
+/// Recursively run cargo check in each package folder from current folder.
+pub fn deep_run() {
+    let cargo_tomls = get_cargo_tomls_deep_recursively(".");
+    for ws_metadata in workspaces(&cargo_tomls).values() {
+        clean_and_check(ws_metadata);
+    }
+}
+
+fn clean_and_check(ws_metadata: &Metadata) {
+    cargo_clean(&ws_metadata.workspace_root);
+    for pkg_folder in get_member_folders(ws_metadata) {
+        super::cargo_check(pkg_folder);
+    }
+}
+
+/// Usually run in workspace root before checking.
+fn cargo_clean(ws_root: &Utf8Path) {
+    rap_info!("cargo clean in workspace root {ws_root}");
+    if let Err(err) = Command::new("cargo")
+        .arg("clean")
+        .current_dir(ws_root)
+        .output()
+    {
+        rap_error_and_exit(format!("`cargo clean` exits unexpectedly:\n{err}"));
+    }
+}
+
+fn get_member_folders(meta: &Metadata) -> Vec<&Utf8Path> {
+    meta.workspace_packages()
+        .iter()
+        .map(|pkg| pkg.manifest_path.parent().unwrap())
+        .collect()
+}
+
+type Workspaces = BTreeMap<Utf8PathBuf, Metadata>;
+
+fn workspace(cargo_toml: &Utf8Path) -> Metadata {
+    let exec = cargo_metadata::MetadataCommand::new()
+        .manifest_path(cargo_toml)
+        .exec();
+    let metadata = match exec {
+        Ok(metadata) => metadata,
+        Err(err) => {
+            let err = format!(
+                "Failed to get the result of cargo metadata \
+                 in {cargo_toml}:\n{err}"
+            );
+            rap_error_and_exit(err)
+        }
+    };
+    metadata
+}
+
+fn workspaces(cargo_tomls: &[Utf8PathBuf]) -> Workspaces {
+    let mut map = BTreeMap::new();
+    for cargo_toml in cargo_tomls {
+        let metadata = workspace(cargo_toml);
+        let root = &metadata.workspace_root;
+        // 每个 member package 解析的 workspace_root 和 members 是一样的
+        if !map.contains_key(root) {
+            map.insert(root.clone(), metadata);
+        }
+    }
+
+    map
+}
+
+fn get_cargo_tomls_deep_recursively(dir: &str) -> Vec<Utf8PathBuf> {
+    walkdir::WalkDir::new(dir)
+        .into_iter()
+        .filter_map(|entry| {
+            if let Ok(e) = entry {
+                if e.file_type().is_file() && e.file_name().to_str()? == "Cargo.toml" {
+                    let path = Utf8PathBuf::from_path_buf(e.into_path());
+                    return path.ok()?.canonicalize_utf8().ok();
+                }
+            }
+            None
+        })
+        .collect()
+}

--- a/rap/src/bin/cargo-rap/cargo_check/workspace.rs
+++ b/rap/src/bin/cargo-rap/cargo_check/workspace.rs
@@ -24,8 +24,12 @@ pub fn deep_run() {
 }
 
 fn check_members(ws_metadata: &Metadata) {
-    // force clean even if `RAP_CLEAN` is false
-    super::cargo_clean(&ws_metadata.workspace_root, true);
+    // Force clean even if `RAP_CLEAN` is false, because rap is in control of
+    // caches for all packages and there should be no cache.
+    let ws_root = &ws_metadata.workspace_root;
+    rap_info!("cargo clean in workspace root {ws_root}");
+    super::cargo_clean(ws_root, true);
+
     for pkg_folder in get_member_folders(ws_metadata) {
         super::cargo_check(pkg_folder);
     }

--- a/rap/src/bin/cargo-rap/help.rs
+++ b/rap/src/bin/cargo-rap/help.rs
@@ -40,13 +40,17 @@ e.g.
 
 Environment Variables (Values are case insensitive):
     RAP_LOG          verbosity of logging: debug, info, warn
+
+    RAP_CLEAN        run cargo clean before check: true, false
+                     * true is the default value except that false is set
+
     RAP_RECURSIVE    scope of packages to check: none, shallow, deep
                      * none or the variable not set: check for current folder
                      * shallow: check for current workpace members
                      * deep: check for all workspaces from current folder
                       
-                     NOTE: for shallow or deep, rap will clean the workspace 
-                     target folder and enter each member to do the check.
+                     NOTE: for shallow or deep, rap will enter each member
+                     folder to do the check.
 "#;
 
 pub const RAP_VERSION: &str = r#"

--- a/rap/src/bin/cargo-rap/help.rs
+++ b/rap/src/bin/cargo-rap/help.rs
@@ -37,6 +37,16 @@ e.g.
    cargo rap -F -M -- --tests
 3. detect use-after-free and memory leak for all members:
    cargo rap -F -M -- --workspace
+
+Environment Variables (Values are case insensitive):
+    RAP_LOG          verbosity of logging: debug, info, warn
+    RAP_RECURSIVE    scope of packages to check: none, shallow, deep
+                     * none or the variable not set: check for current folder
+                     * shallow: check for current workpace members
+                     * deep: check for all workspaces from current folder
+                      
+                     NOTE: for shallow or deep, rap will clean the workspace 
+                     target folder and enter each member to do the check.
 "#;
 
 pub const RAP_VERSION: &str = r#"

--- a/rap/src/bin/cargo-rap/main.rs
+++ b/rap/src/bin/cargo-rap/main.rs
@@ -36,7 +36,7 @@ fn phase_cargo_rap() {
         _ => {}
     }
 
-    cargo_check::run();
+    cargo_check::default_run();
 }
 
 fn phase_rustc_wrapper() {

--- a/rap/src/bin/cargo-rap/main.rs
+++ b/rap/src/bin/cargo-rap/main.rs
@@ -36,7 +36,7 @@ fn phase_cargo_rap() {
         _ => {}
     }
 
-    cargo_check::default_run();
+    cargo_check::run();
 }
 
 fn phase_rustc_wrapper() {


### PR DESCRIPTION
This PR introduce RAP_CLEAN and RAP_CLEAN environment variables:

Environment variables (Values are case insensitive):
| var             | default when absent | one of these values | description                  |
|-----------------|---------------------|---------------------|------------------------------|
| `RAP_CLEAN`     | true                | ture, false         | run cargo clean before check |
| `RAP_RECURSIVE` | none                | none, shallow, deep | scope of packages to check   |

For `RAP_RECURSIVE`:
* none: check for current folder
* shallow: check for current workpace members
* deep: check for all workspaces from current folder
 
NOTE: for shallow or deep, rap will enter each member folder to do the check.

---

Output of this PR: https://github.com/os-checker/os-checker-test-suite/blob/480055aec08e0d607c683d532b44d4e072238f68/rap.md
