### PR TITLE
Modify analysis result format in senryx

### DIFF
--- a/rap/src/analysis/senryx/contracts/checker.rs
+++ b/rap/src/analysis/senryx/contracts/checker.rs
@@ -25,10 +25,10 @@ impl<T> SliceFromRawPartsChecker<T> {
         map.insert(
             0,
             vec![
-                Contract::StateCheck {
-                    op: Op::GE,
-                    state: StateType::AllocatedState(AllocatedState::Alloc),
-                },
+                // Contract::StateCheck {
+                //     op: Op::GE,
+                //     state: StateType::AllocatedState(AllocatedState::Alloc),
+                // },
                 Contract::StateCheck {
                     op: Op::GT,
                     state: StateType::AlignState(AlignState::Unaligned),

--- a/rap/src/analysis/senryx/matcher.rs
+++ b/rap/src/analysis/senryx/matcher.rs
@@ -1,5 +1,6 @@
 use rustc_middle::mir::Operand;
 use rustc_span::source_map::Spanned;
+use rustc_span::Span;
 
 use super::{
     contracts::{
@@ -14,6 +15,7 @@ pub fn match_unsafe_api_and_check_contracts<T>(
     func_name: &str,
     args: &Box<[Spanned<Operand>]>,
     abstate: &AbstractState,
+    span: Span,
     _ty: T,
 ) -> Option<CheckResult> {
     let base_func_name = func_name.split::<&str>("<").next().unwrap_or(func_name);
@@ -26,7 +28,7 @@ pub fn match_unsafe_api_and_check_contracts<T>(
     };
 
     if let Some(c) = checker {
-        return Some(process_checker(&*c, args, abstate, base_func_name));
+        return Some(process_checker(&*c, args, abstate, base_func_name, span));
     }
     None
 }
@@ -36,8 +38,9 @@ fn process_checker(
     args: &Box<[Spanned<Operand>]>,
     abstate: &AbstractState,
     func_name: &str,
+    span: Span,
 ) -> CheckResult {
-    let mut check_result = CheckResult::new(func_name);
+    let mut check_result = CheckResult::new(func_name, span);
     for (idx, contracts_vec) in checker.variable_contracts().iter() {
         for contract in contracts_vec {
             let arg_place = get_arg_place(&args[*idx].node);

--- a/rap/src/analysis/utils/show_mir.rs
+++ b/rap/src/analysis/utils/show_mir.rs
@@ -191,8 +191,8 @@ pub struct ShowMir<'tcx> {
     pub tcx: TyCtxt<'tcx>,
 }
 
-#[inline(always)]
-fn display_mir(did: DefId, body: &Body) {
+// #[inline(always)]
+pub fn display_mir(did: DefId, body: &Body) {
     rap_info!("{}", did.display().color(Color::LightRed));
     rap_info!("{}", body.local_decls.display().color(Color::Green));
     rap_info!(


### PR DESCRIPTION
This pr modifies the previous senryx checking result output format, and make the output information dependent on the path. 

This means that the path to triggering a bug can be given based on the output information in the future.