### PR TITLE
Change API definition in dataflow graph

### DIFF
--- a/rap/src/analysis/core/dataflow/debug.rs
+++ b/rap/src/analysis/core/dataflow/debug.rs
@@ -17,47 +17,13 @@ impl GraphEdge {
     pub fn to_dot_graph<'tcx>(&self) -> String {
         let mut attr = String::new();
         let mut dot = String::new();
-        match self {
-            //label=xxx
-            GraphEdge::NodeEdge {
-                src: _,
-                dst: _,
-                op,
-                seq,
-            } => {
-                write!(
-                    attr,
-                    "label=\"{}\" ",
-                    escaped_string(format!("{}_{:?}", seq, op))
-                )
-                .unwrap();
-            }
-            GraphEdge::ConstEdge {
-                src: _,
-                dst: _,
-                op,
-                seq,
-            } => {
-                write!(
-                    attr,
-                    "label=\"{}\" ",
-                    escaped_string(format!("{}_{:?}", seq, op))
-                )
-                .unwrap();
-            }
-        }
-        match self {
-            GraphEdge::NodeEdge {
-                src, dst, op: _, ..
-            } => {
-                write!(dot, "{:?} -> {:?} [{}]", src, dst, attr).unwrap();
-            }
-            GraphEdge::ConstEdge {
-                src, dst, op: _, ..
-            } => {
-                write!(dot, "{:?} -> {:?} [{}]", src, dst, attr).unwrap();
-            }
-        }
+        write!(
+            attr,
+            "label=\"{}\" ",
+            escaped_string(format!("{}_{:?}", self.seq, self.op))
+        )
+        .unwrap();
+        write!(dot, "{:?} -> {:?} [{}]", self.src, self.dst, attr).unwrap();
         dot
     }
 }
@@ -80,6 +46,14 @@ impl GraphNode {
                 } else {
                     write!(attr, "label=\"<f0> {:?}\" ", local).unwrap();
                 }
+            }
+            NodeOp::Const(ref name) => {
+                write!(
+                    attr,
+                    "label=\"<f0> {}\" style=dashed ",
+                    escaped_string(name.clone())
+                )
+                .unwrap();
             }
             NodeOp::Call(def_id) => {
                 let func_name = tcx.def_path_str(def_id);

--- a/rap/src/analysis/opt/checking/bounds_checking/bounds_len.rs
+++ b/rap/src/analysis/opt/checking/bounds_checking/bounds_len.rs
@@ -71,7 +71,7 @@ fn find_upside_vec_len_node(graph: &Graph, node_idx: Local) -> Option<Local> {
     let def_paths = &DEFPATHS.get().unwrap();
     let target_def_id = def_paths.vec_len.last_def_id();
     // Warning: may traverse all upside nodes and the new result will overwrite on the previous result
-    let mut node_operator = |idx: Local| -> DFSStatus {
+    let mut node_operator = |graph: &Graph, idx: Local| -> DFSStatus {
         let node = &graph.nodes[idx];
         if let NodeOp::Call(def_id) = node.op {
             if def_id == target_def_id {
@@ -95,7 +95,7 @@ fn find_downside_index_node(graph: &Graph, node_idx: Local) -> Vec<Local> {
     let mut index_node_idxs: Vec<Local> = Vec::new();
     let def_paths = &DEFPATHS.get().unwrap();
     // Warning: traverse all downside nodes
-    let mut node_operator = |idx: Local| -> DFSStatus {
+    let mut node_operator = |graph: &Graph, idx: Local| -> DFSStatus {
         let node = &graph.nodes[idx];
         if let NodeOp::Call(def_id) = node.op {
             if def_id == def_paths.ops_index.last_def_id()

--- a/rap/src/analysis/opt/checking/bounds_checking/bounds_len.rs
+++ b/rap/src/analysis/opt/checking/bounds_checking/bounds_len.rs
@@ -4,10 +4,9 @@ use rustc_middle::mir::Local;
 use rustc_middle::ty::TyCtxt;
 
 use crate::analysis::core::dataflow::graph::{
-    AggKind, DFSStatus, Direction, Graph, GraphEdge, GraphNode, NodeOp,
+    AggKind, DFSStatus, Direction, Graph, GraphNode, NodeOp,
 };
 use crate::analysis::utils::def_path::DefPath;
-use crate::rap_debug;
 use crate::utils::log::{
     relative_pos_range, span_to_filename, span_to_line_number, span_to_source_code,
 };
@@ -61,11 +60,7 @@ fn extract_upperbound_node_if_ops_range(graph: &Graph, node: &GraphNode) -> Opti
     if let NodeOp::Aggregate(AggKind::Adt(def_id)) = node.op {
         if def_id == target_def_id {
             let upperbound_edge = &graph.edges[node.in_edges[1]]; // the second field
-            if let GraphEdge::NodeEdge { src, .. } = upperbound_edge {
-                return Some(*src);
-            } else {
-                rap_debug!("The upperbound edge of Agg node is not a NodeEdge");
-            }
+            return Some(upperbound_edge.src);
         }
     }
     None

--- a/rap/src/analysis/opt/memory_cloning/hash_key_cloning.rs
+++ b/rap/src/analysis/opt/memory_cloning/hash_key_cloning.rs
@@ -71,7 +71,7 @@ fn find_first_param_upside_clone(graph: &Graph, node: &GraphNode) -> Option<Loca
     let mut clone_node_idx = None;
     let def_paths = &DEFPATHS.get().unwrap();
     let target_def_id = def_paths.clone.last_def_id();
-    let mut node_operator = |idx: Local| -> DFSStatus {
+    let mut node_operator = |graph: &Graph, idx: Local| -> DFSStatus {
         let node = &graph.nodes[idx];
         if let NodeOp::Call(def_id) = node.op {
             if def_id == target_def_id {
@@ -96,7 +96,7 @@ fn find_hashset_new_node(graph: &Graph, node: &GraphNode) -> Option<Local> {
     let mut new_node_idx = None;
     let def_paths = &DEFPATHS.get().unwrap();
     let target_def_id = def_paths.hashset_new.last_def_id();
-    let mut node_operator = |idx: Local| -> DFSStatus {
+    let mut node_operator = |graph: &Graph, idx: Local| -> DFSStatus {
         let node = &graph.nodes[idx];
         if let NodeOp::Call(def_id) = node.op {
             if def_id == target_def_id {


### PR DESCRIPTION
- Remove `ConstEdge` and add `NodeOp::Const`. Now `GraphEdge` is a `struct` instead of an `enum`.
- Previously, the node operator (a closure) of DFS catched graph outside. Now we explicitly pass a graph as its parameter. Correspondingly, the edge operator also takes a graph and an `EdgeIdx` (instead of EdgeOp) as parameters. So now we have more flexibility to read data whether from nodes or edges during DFS.