### PR TITLE
feat: cloned value used as immutable

### DIFF
--- a/rap/src/analysis/opt.rs
+++ b/rap/src/analysis/opt.rs
@@ -5,7 +5,7 @@ use rustc_middle::ty::TyCtxt;
 
 use super::core::dataflow::DataFlow;
 use checking::bounds_checking;
-use memory_cloning::hash_key_cloning;
+use memory_cloning::used_as_immutable;
 
 pub struct Opt<'tcx> {
     pub tcx: TyCtxt<'tcx>,
@@ -21,7 +21,7 @@ impl<'tcx> Opt<'tcx> {
         dataflow.build_graphs();
         for (_, graph) in dataflow.graphs.iter() {
             bounds_checking::check(graph, &self.tcx);
-            hash_key_cloning::check(graph, &self.tcx);
+            used_as_immutable::check(graph, &self.tcx);
         }
     }
 }

--- a/rap/src/analysis/opt/memory_cloning.rs
+++ b/rap/src/analysis/opt/memory_cloning.rs
@@ -1,1 +1,2 @@
 pub mod hash_key_cloning;
+pub mod used_as_immutable;

--- a/rap/src/analysis/opt/memory_cloning/used_as_immutable.rs
+++ b/rap/src/analysis/opt/memory_cloning/used_as_immutable.rs
@@ -1,0 +1,115 @@
+use annotate_snippets::Level;
+use annotate_snippets::Renderer;
+use annotate_snippets::Snippet;
+use once_cell::sync::OnceCell;
+
+use crate::analysis::core::dataflow::graph::DFSStatus;
+use crate::analysis::core::dataflow::graph::Direction;
+use crate::analysis::core::dataflow::graph::EdgeIdx;
+use rustc_middle::mir::Local;
+use rustc_middle::ty::{TyCtxt, TyKind};
+use rustc_span::Span;
+use std::cell::Cell;
+static DEFPATHS: OnceCell<DefPaths> = OnceCell::new();
+
+use crate::analysis::core::dataflow::graph::Graph;
+use crate::analysis::core::dataflow::graph::NodeOp;
+use crate::analysis::utils::def_path::DefPath;
+use crate::utils::log::{
+    relative_pos_range, span_to_filename, span_to_line_number, span_to_source_code,
+};
+
+struct DefPaths {
+    clone: DefPath,
+}
+
+impl DefPaths {
+    pub fn new(tcx: &TyCtxt<'_>) -> Self {
+        Self {
+            clone: DefPath::new("std::clone::Clone::clone", tcx),
+        }
+    }
+}
+
+// whether the cloned value is used as a parameter
+fn find_downside_use_as_param(graph: &Graph, clone_node_idx: Local) -> Option<(Local, EdgeIdx)> {
+    let mut record = None;
+    let edge_idx = Cell::new(0 as usize);
+    let mut node_operator = |graph: &Graph, idx: Local| {
+        if idx == clone_node_idx {
+            return DFSStatus::Continue; //the start point, clone, is a Call node as well
+        }
+        let node = &graph.nodes[idx];
+        if let NodeOp::Call(_) = node.op {
+            record = Some((idx, edge_idx.get())); //here, the edge_idx must be the upside edge of the node
+            return DFSStatus::Stop;
+        }
+        DFSStatus::Continue
+    };
+    let mut edge_operator = |graph: &Graph, idx: EdgeIdx| {
+        edge_idx.set(idx);
+        Graph::equivalent_edge_validator(graph, idx)
+    };
+    graph.dfs(
+        clone_node_idx,
+        Direction::Downside,
+        &mut node_operator,
+        &mut edge_operator,
+        true,
+    );
+    record
+}
+
+pub fn check(graph: &Graph, tcx: &TyCtxt) {
+    let _ = &DEFPATHS.get_or_init(|| DefPaths::new(tcx));
+    let def_paths = &DEFPATHS.get().unwrap();
+    let target_def_id = def_paths.clone.last_def_id();
+    for (idx, node) in graph.nodes.iter_enumerated() {
+        if let NodeOp::Call(def_id) = node.op {
+            if def_id == target_def_id {
+                if let Some((node_idx, edge_idx)) = find_downside_use_as_param(graph, idx) {
+                    if let NodeOp::Call(callee_def_id) = graph.nodes[node_idx].op {
+                        let fn_sig = tcx.normalize_erasing_late_bound_regions(
+                            rustc_middle::ty::ParamEnv::reveal_all(),
+                            tcx.fn_sig(callee_def_id).skip_binder(),
+                        );
+                        let use_node = &graph.nodes[node_idx];
+                        let index = use_node.in_edges.binary_search(&edge_idx).unwrap();
+                        let ty = fn_sig.inputs().iter().nth(index).unwrap();
+                        if !matches!(ty.kind(), TyKind::Ref(..)) {
+                            //not &T or &mut T
+                            let clone_span = node.span;
+                            let use_span = use_node.span;
+                            report_used_as_immutable(graph, clone_span, use_span);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn report_used_as_immutable(graph: &Graph, clone_span: Span, use_span: Span) {
+    let code_source = span_to_source_code(graph.span);
+    let filename = span_to_filename(clone_span);
+    let snippet = Snippet::source(&code_source)
+        .line_start(span_to_line_number(graph.span))
+        .origin(&filename)
+        .fold(true)
+        .annotation(
+            Level::Error
+                .span(relative_pos_range(graph.span, clone_span))
+                .label("Cloning happens here."),
+        )
+        .annotation(
+            Level::Error
+                .span(relative_pos_range(graph.span, use_span))
+                .label("Used here"),
+        );
+    let message = Level::Warning
+        .title("Unnecessary memory cloning detected")
+        .snippet(snippet)
+        .footer(Level::Help.title("Use borrowings instead."));
+    let renderer = Renderer::styled();
+    println!("{}", renderer.render(message));
+}


### PR DESCRIPTION
- detect `cloned value used as immutable`
- temporarily remove detection of `hash key cloning` in the main function because the exception is covered