### PR TITLE
rewrite bug report of safedrop

### DIFF
--- a/rap/src/analysis/opt/checking/bounds_checking/bounds_len.rs
+++ b/rap/src/analysis/opt/checking/bounds_checking/bounds_len.rs
@@ -126,14 +126,14 @@ fn report_upperbound_bug(graph: &Graph, upperbound_node_idx: Local, index_record
         .fold(true)
         .annotation(
             Level::Info
-                .span(relative_pos_range(graph.span, upperbound_span))
+                .span(unsafe { relative_pos_range(graph.span, upperbound_span) })
                 .label("Index is upperbounded."),
         );
     for node_idx in index_record {
         let index_span = graph.nodes[*node_idx].span;
         snippet = snippet.annotation(
             Level::Error
-                .span(relative_pos_range(graph.span, index_span))
+                .span(unsafe { relative_pos_range(graph.span, index_span) })
                 .label("Checked here."),
         );
     }

--- a/rap/src/analysis/opt/checking/bounds_checking/bounds_loop_push.rs
+++ b/rap/src/analysis/opt/checking/bounds_checking/bounds_loop_push.rs
@@ -86,16 +86,18 @@ fn report_loop_push_bug(loop_span: Span, push_record: &Vec<Span>) {
         .fold(true)
         .annotation(
             Level::Info
-                .span(relative_pos_range(
-                    loop_span,
-                    span_to_trimmed_span(span_to_first_line(loop_span)),
-                ))
+                .span(unsafe {
+                    relative_pos_range(
+                        loop_span,
+                        span_to_trimmed_span(span_to_first_line(loop_span)),
+                    )
+                })
                 .label("A loop operation."),
         );
     for push_span in push_record {
         snippet = snippet.annotation(
             Level::Error
-                .span(relative_pos_range(loop_span, *push_span))
+                .span(unsafe { relative_pos_range(loop_span, *push_span) })
                 .label("Push happens here."),
         );
     }

--- a/rap/src/analysis/opt/memory_cloning/hash_key_cloning.rs
+++ b/rap/src/analysis/opt/memory_cloning/hash_key_cloning.rs
@@ -125,12 +125,12 @@ fn report_hash_key_cloning(graph: &Graph, clone_span: Span, insert_span: Span) {
         .fold(true)
         .annotation(
             Level::Error
-                .span(relative_pos_range(graph.span, clone_span))
+                .span(unsafe { relative_pos_range(graph.span, clone_span) })
                 .label("Cloning happens here."),
         )
         .annotation(
             Level::Error
-                .span(relative_pos_range(graph.span, insert_span))
+                .span(unsafe { relative_pos_range(graph.span, insert_span) })
                 .label("Used here."),
         );
     let message = Level::Warning

--- a/rap/src/analysis/opt/memory_cloning/used_as_immutable.rs
+++ b/rap/src/analysis/opt/memory_cloning/used_as_immutable.rs
@@ -98,12 +98,12 @@ fn report_used_as_immutable(graph: &Graph, clone_span: Span, use_span: Span) {
         .fold(true)
         .annotation(
             Level::Error
-                .span(relative_pos_range(graph.span, clone_span))
+                .span(unsafe { relative_pos_range(graph.span, clone_span) })
                 .label("Cloning happens here."),
         )
         .annotation(
             Level::Error
-                .span(relative_pos_range(graph.span, use_span))
+                .span(unsafe { relative_pos_range(graph.span, use_span) })
                 .label("Used here"),
         );
     let message = Level::Warning

--- a/rap/src/analysis/safedrop/bug_records.rs
+++ b/rap/src/analysis/safedrop/bug_records.rs
@@ -1,6 +1,10 @@
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_span::Span;
 
+use crate::rap_warn;
+use crate::utils::log::are_spans_in_same_file;
+use rustc_span::symbol::Symbol;
+
 use annotate_snippets::Level;
 use annotate_snippets::Renderer;
 use annotate_snippets::Snippet;
@@ -35,8 +39,9 @@ impl BugRecords {
             && self.dp_bugs_unwind.is_empty()
     }
 
-    pub fn df_bugs_output(&self, span: Span) {
+    pub fn df_bugs_output(&self, fn_name: Symbol, span: Span) {
         if !self.df_bugs.is_empty() {
+            rap_warn!("Double free detected in function {:}", fn_name);
             let code_source = span_to_source_code(span);
             let filename = span_to_filename(span);
             let mut snippet = Snippet::source(&code_source)
@@ -44,11 +49,14 @@ impl BugRecords {
                 .origin(&filename)
                 .fold(true);
             for i in self.df_bugs.iter() {
-                snippet = snippet.annotation(
-                    Level::Warning
-                        .span(relative_pos_range(span, *i.1))
-                        .label("Double free detected."),
-                );
+                //todo: remove this condition
+                if are_spans_in_same_file(span, *i.1) {
+                    snippet = snippet.annotation(
+                        Level::Warning
+                            .span(unsafe { relative_pos_range(span, *i.1) })
+                            .label("Double free detected."),
+                    );
+                }
             }
             let message = Level::Warning
                 .title("Double free detected.")
@@ -58,8 +66,9 @@ impl BugRecords {
         }
     }
 
-    pub fn uaf_bugs_output(&self, span: Span) {
+    pub fn uaf_bugs_output(&self, fn_name: Symbol, span: Span) {
         if !self.uaf_bugs.is_empty() {
+            rap_warn!("Use after free detected in function {:?}", fn_name);
             let code_source = span_to_source_code(span);
             let filename = span_to_filename(span);
             let mut snippet = Snippet::source(&code_source)
@@ -67,12 +76,14 @@ impl BugRecords {
                 .origin(&filename)
                 .fold(true);
             for i in self.uaf_bugs.iter() {
-                snippet = snippet.annotation(
-                    Level::Warning
-                        .span(relative_pos_range(span, *i))
-                        .label("Use after free detected."),
-                );
-                println!("{:?}", *i);
+                //todo: remove this condition
+                if are_spans_in_same_file(span, *i) {
+                    snippet = snippet.annotation(
+                        Level::Warning
+                            .span(unsafe { relative_pos_range(span, *i) })
+                            .label("Use after free detected."),
+                    );
+                }
             }
             let message = Level::Warning
                 .title("Use after free detected.")
@@ -82,31 +93,55 @@ impl BugRecords {
         }
     }
 
-    pub fn dp_bug_output(&self, span: Span) {
+    pub fn dp_bug_output(&self, fn_name: Symbol, span: Span) {
         let code_source = span_to_source_code(span);
         let filename = span_to_filename(span);
-        let mut snippet = Snippet::source(&code_source)
-            .line_start(span_to_line_number(span))
-            .origin(&filename)
-            .fold(true);
-        for i in self.dp_bugs.iter() {
-            snippet = snippet.annotation(
-                Level::Warning
-                    .span(relative_pos_range(span, *i))
-                    .label("Dangling pointer detected."),
-            );
+        if !self.dp_bugs.is_empty() {
+            rap_warn!("Dangling pointer detected in function {:?}", fn_name);
+            let mut snippet = Snippet::source(&code_source)
+                .line_start(span_to_line_number(span))
+                .origin(&filename)
+                .fold(true);
+            for i in self.dp_bugs.iter() {
+                //todo: remove this condition
+                if are_spans_in_same_file(span, *i) {
+                    snippet = snippet.annotation(
+                        Level::Warning
+                            .span(unsafe { relative_pos_range(span, *i) })
+                            .label("Dangling pointer detected."),
+                    );
+                }
+            }
+            let message = Level::Warning
+                .title("Dangling pointer detected.")
+                .snippet(snippet);
+            let renderer = Renderer::styled();
+            println!("{}", renderer.render(message));
         }
-        for i in self.dp_bugs_unwind.iter() {
-            snippet = snippet.annotation(
-                Level::Warning
-                    .span(relative_pos_range(span, *i))
-                    .label("Dangling pointer detected during unwinding."),
+        if !self.dp_bugs_unwind.is_empty() {
+            rap_warn!(
+                "Dangling pointer detected in function {:?} during unwinding.",
+                fn_name
             );
+            let mut snippet = Snippet::source(&code_source)
+                .line_start(span_to_line_number(span))
+                .origin(&filename)
+                .fold(true);
+            for i in self.dp_bugs_unwind.iter() {
+                //todo: remove this condition
+                if are_spans_in_same_file(span, *i) {
+                    snippet = snippet.annotation(
+                        Level::Warning
+                            .span(unsafe { relative_pos_range(span, *i) })
+                            .label("Dangling pointer detected during unwinding."),
+                    );
+                }
+            }
+            let message = Level::Warning
+                .title("Dangling pointer detected during unwinding.")
+                .snippet(snippet);
+            let renderer = Renderer::styled();
+            println!("{}", renderer.render(message));
         }
-        let message = Level::Warning
-            .title("Dangling pointer detected.")
-            .snippet(snippet);
-        let renderer = Renderer::styled();
-        println!("{}", renderer.render(message));
     }
 }

--- a/rap/src/analysis/safedrop/check_bugs.rs
+++ b/rap/src/analysis/safedrop/check_bugs.rs
@@ -2,6 +2,7 @@ use super::graph::*;
 use crate::utils::source::*;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_middle::mir::SourceInfo;
+use rustc_span::symbol::Symbol;
 use rustc_span::Span;
 
 impl<'tcx> SafeDropGraph<'tcx> {
@@ -18,9 +19,13 @@ impl<'tcx> SafeDropGraph<'tcx> {
         if self.bug_records.is_bug_free() {
             return;
         }
-        self.bug_records.df_bugs_output(self.span);
-        self.bug_records.uaf_bugs_output(self.span);
-        self.bug_records.dp_bug_output(self.span);
+        let fn_name = match get_name(self.tcx, self.def_id) {
+            Some(name) => name,
+            None => Symbol::intern("no symbol available"),
+        };
+        self.bug_records.df_bugs_output(fn_name, self.span);
+        self.bug_records.uaf_bugs_output(fn_name, self.span);
+        self.bug_records.dp_bug_output(fn_name, self.span);
     }
 
     pub fn uaf_check(&mut self, aliaset_idx: usize, span: Span, local: usize, is_func_call: bool) {

--- a/rap/src/analysis/safedrop/check_bugs.rs
+++ b/rap/src/analysis/safedrop/check_bugs.rs
@@ -2,7 +2,6 @@ use super::graph::*;
 use crate::utils::source::*;
 use rustc_data_structures::fx::FxHashSet;
 use rustc_middle::mir::SourceInfo;
-use rustc_span::symbol::Symbol;
 use rustc_span::Span;
 
 impl<'tcx> SafeDropGraph<'tcx> {
@@ -19,13 +18,9 @@ impl<'tcx> SafeDropGraph<'tcx> {
         if self.bug_records.is_bug_free() {
             return;
         }
-        let fn_name = match get_name(self.tcx, self.def_id) {
-            Some(name) => name,
-            None => Symbol::intern("no symbol available"),
-        };
-        self.bug_records.df_bugs_output(fn_name);
-        self.bug_records.uaf_bugs_output(fn_name);
-        self.bug_records.dp_bug_output(fn_name);
+        self.bug_records.df_bugs_output(self.span);
+        self.bug_records.uaf_bugs_output(self.span);
+        self.bug_records.dp_bug_output(self.span);
     }
 
     pub fn uaf_check(&mut self, aliaset_idx: usize, span: Span, local: usize, is_func_call: bool) {

--- a/rap/src/utils/log.rs
+++ b/rap/src/utils/log.rs
@@ -133,9 +133,16 @@ pub fn span_to_line_number(span: Span) -> usize {
 }
 
 #[inline]
-pub fn relative_pos_range(span: Span, sub_span: Span) -> Range<usize> {
+// this function computes the relative pos range of two spans which could be generated from two dirrerent files or not intersect with each other
+pub unsafe fn relative_pos_range(span: Span, sub_span: Span) -> Range<usize> {
     let start_pos = span.lo();
-    let lo = (sub_span.lo() - start_pos).to_usize();
+    let lo = (sub_span.lo() - start_pos).to_usize(); //unsafe: overflow
     let hi = (sub_span.hi() - start_pos).to_usize();
     lo..hi
+}
+
+pub fn are_spans_in_same_file(span1: Span, span2: Span) -> bool {
+    let file1 = get_source_map().unwrap().lookup_source_file(span1.lo());
+    let file2 = get_source_map().unwrap().lookup_source_file(span2.lo());
+    file1.name == file2.name
 }


### PR DESCRIPTION
Use annotate_anippet to rewrite the bug report of safedrop.
Now safedrop still `reports` spans from non-local source code. Thus I add a condition which filters out the special cases.

During the debugging, I find that `relative_pos_range` API may have overflow problems. Therefore, an `unsafe` keyword is added in this function's declaration.