### PR TITLE
Add orchestration layer for verification

### DIFF
--- a/rapx/src/verify/driver.rs
+++ b/rapx/src/verify/driver.rs
@@ -11,6 +11,7 @@ use super::{
     contract::Property,
     helpers::{Callsite, collect_unsafe_callsites},
     path::{Path, PathExtractor, PathResult},
+    report::{CheckResult, PropertyCheckResult, VerificationReport},
     target::FunctionTarget,
 };
 
@@ -43,6 +44,35 @@ impl<'tcx> VerifyDriver<'tcx> {
     pub fn build_path_result(&self, target: &FunctionTarget<'tcx>) -> PathResult<'tcx> {
         let callsites = self.collect_callsites(target);
         self.extract_paths(target, callsites)
+    }
+
+    /// Run the current staged verifier pipeline for one function target.
+    ///
+    /// This method is the main driver entry for later verification stages.  It
+    /// currently builds callsites and paths, pairs each callsite with the
+    /// required properties stored in `FunctionTarget::callee_requires`, and
+    /// records an `Unknown` result for every `(callsite, path, property)` item.
+    /// Evidence reduction, abstract replay, and SMT checking can replace the
+    /// placeholder result inside this loop without changing the surrounding
+    /// control flow.
+    pub fn verify_function(&self, target: &FunctionTarget<'tcx>) -> VerificationReport<'tcx> {
+        let path_result = self.build_path_result(target);
+        let mut report = VerificationReport::new(target.def_id);
+
+        for view in self.iter_callsite_checks(target, &path_result) {
+            for (path_index, _path) in view.paths.iter().enumerate() {
+                for property in view.requires {
+                    report.push(PropertyCheckResult {
+                        callsite: view.callsite.location(),
+                        path_index,
+                        property: property.clone(),
+                        result: CheckResult::Unknown,
+                    });
+                }
+            }
+        }
+
+        report
     }
 
     /// Return the required properties for a concrete unsafe callsite.

--- a/rapx/src/verify/driver.rs
+++ b/rapx/src/verify/driver.rs
@@ -1,0 +1,87 @@
+//! Driver utilities for the staged verifier pipeline.
+//!
+//! The target collector owns the list of functions and their required callee
+//! contracts.  The path extractor owns loop-aware paths to concrete unsafe
+//! callsites.  This module connects those pieces without introducing another
+//! storage model for obligations.
+
+use rustc_middle::ty::TyCtxt;
+
+use super::{
+    contract::Property,
+    helpers::{Callsite, collect_unsafe_callsites},
+    path::{Path, PathExtractor, PathResult},
+    target::FunctionTarget,
+};
+
+/// Entry point for building callsite-level verification inputs.
+pub struct VerifyDriver<'tcx> {
+    tcx: TyCtxt<'tcx>,
+}
+
+impl<'tcx> VerifyDriver<'tcx> {
+    /// Create a verifier driver over the current compiler type context.
+    pub fn new(tcx: TyCtxt<'tcx>) -> Self {
+        Self { tcx }
+    }
+
+    /// Collect concrete unsafe callsites from a function target.
+    pub fn collect_callsites(&self, target: &FunctionTarget<'tcx>) -> Vec<Callsite<'tcx>> {
+        collect_unsafe_callsites(self.tcx, target.def_id)
+    }
+
+    /// Extract loop-aware paths for the given target and callsites.
+    pub fn extract_paths(
+        &self,
+        target: &FunctionTarget<'tcx>,
+        callsites: Vec<Callsite<'tcx>>,
+    ) -> PathResult<'tcx> {
+        PathExtractor::new(self.tcx, target.def_id, callsites).run()
+    }
+
+    /// Collect callsites and extract paths for one function target.
+    pub fn build_path_result(&self, target: &FunctionTarget<'tcx>) -> PathResult<'tcx> {
+        let callsites = self.collect_callsites(target);
+        self.extract_paths(target, callsites)
+    }
+
+    /// Return the required properties for a concrete unsafe callsite.
+    pub fn requires_for_callsite<'a>(
+        &self,
+        target: &'a FunctionTarget<'tcx>,
+        callsite: &Callsite<'tcx>,
+    ) -> &'a [Property<'tcx>] {
+        target
+            .callee_requires
+            .get(&callsite.callee)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+    }
+
+    /// Iterate over callsites together with their paths and required properties.
+    pub fn iter_callsite_checks<'a>(
+        &'a self,
+        target: &'a FunctionTarget<'tcx>,
+        path_result: &'a PathResult<'tcx>,
+    ) -> impl Iterator<Item = CallsiteCheckView<'a, 'tcx>> + 'a {
+        path_result.callsites().iter().map(move |callsite| {
+            let paths = path_result.paths_for(callsite.location());
+            let requires = self.requires_for_callsite(target, callsite);
+            CallsiteCheckView {
+                callsite,
+                paths,
+                requires,
+            }
+        })
+    }
+}
+
+/// Borrowed view of all verification inputs for one unsafe callsite.
+pub struct CallsiteCheckView<'a, 'tcx> {
+    /// The concrete unsafe callsite in the caller MIR body.
+    pub callsite: &'a Callsite<'tcx>,
+    /// Loop-aware paths that can reach this callsite.
+    pub paths: &'a [Path],
+    /// Required safety properties for the unsafe callee.
+    pub requires: &'a [Property<'tcx>],
+}

--- a/rapx/src/verify/evidence.rs
+++ b/rapx/src/verify/evidence.rs
@@ -1,0 +1,341 @@
+//! Backward evidence data model for the staged verifier.
+//!
+//! This module defines the structures used by the future backward evidence
+//! reducer.  It also provides property-root extraction without making the
+//! contract layer depend on the evidence layer.
+
+use rustc_data_structures::fx::FxHashSet;
+use rustc_middle::mir::{BasicBlock, Local};
+use rustc_middle::ty::TyCtxt;
+
+use super::{
+    contract::{
+        ContractExpr, ContractPlace, ContractProjection, NumericPredicate, PlaceBase, Property,
+        PropertyArg, PropertyKind,
+    },
+    helpers::CallsiteLocation,
+    path::{Path, PathStep},
+};
+
+/// Entry point for future backward evidence reduction.
+pub struct EvidenceReducer<'tcx> {
+    tcx: TyCtxt<'tcx>,
+}
+
+impl<'tcx> EvidenceReducer<'tcx> {
+    /// Create an evidence reducer over the current compiler type context.
+    pub fn new(tcx: TyCtxt<'tcx>) -> Self {
+        Self { tcx }
+    }
+
+    /// Return the compiler type context owned by this reducer.
+    pub fn tcx(&self) -> TyCtxt<'tcx> {
+        self.tcx
+    }
+
+    /// Build the initial reduced-evidence object for a path and property.
+    ///
+    /// This is intentionally a lightweight stub for the next phase: it records
+    /// the property roots but does not yet walk MIR statements.  Step 3 will
+    /// replace the empty `items` vector with the actual backward slice.
+    pub fn seed(
+        &self,
+        callsite: CallsiteLocation,
+        path: &Path,
+        property: &Property<'tcx>,
+    ) -> ReducedEvidence<'tcx> {
+        ReducedEvidence {
+            callsite,
+            property: property.clone(),
+            path: path.clone(),
+            items: Vec::new(),
+            roots: RelevanceSet::from_property(property),
+        }
+    }
+}
+
+/// Reduced evidence retained for one `(callsite, path, property)` item.
+#[derive(Clone, Debug)]
+pub struct ReducedEvidence<'tcx> {
+    /// Unsafe callsite whose obligation is being checked.
+    pub callsite: CallsiteLocation,
+    /// Required property that determines the relevance roots.
+    pub property: Property<'tcx>,
+    /// Path being reduced.
+    pub path: Path,
+    /// Evidence retained from the path.
+    pub items: Vec<EvidenceItem<'tcx>>,
+    /// Initial roots extracted from the property.
+    pub roots: RelevanceSet,
+}
+
+impl<'tcx> ReducedEvidence<'tcx> {
+    /// Append one evidence item to the reduced path.
+    pub fn push(&mut self, item: EvidenceItem<'tcx>) {
+        self.items.push(item);
+    }
+
+    /// Return true when no MIR/path evidence has been retained yet.
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+}
+
+/// One retained evidence item from a path.
+#[derive(Clone, Debug)]
+pub enum EvidenceItem<'tcx> {
+    /// A MIR statement retained from a basic block.
+    Statement {
+        block: BasicBlock,
+        statement_index: usize,
+        kind: EvidenceKind,
+    },
+    /// A MIR terminator retained from a basic block.
+    Terminator {
+        block: BasicBlock,
+        kind: EvidenceKind,
+    },
+    /// A path-level step retained as structural evidence.
+    PathStep { step: PathStep, kind: EvidenceKind },
+    /// A contract fact retained as evidence.
+    ContractFact { property: Property<'tcx> },
+    /// A conservative loss of precision for relevant state.
+    Havoc { reason: HavocReason },
+}
+
+/// Why a retained item is relevant.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EvidenceKind {
+    /// The item defines a relevant place.
+    Definition,
+    /// The item contributes a branch/path condition.
+    PathCondition,
+    /// The item contributes pointer provenance or pointer arithmetic.
+    PointerProvenance,
+    /// The item refines state through a runtime check.
+    RuntimeCheck,
+    /// The item is the unsafe callsite being checked.
+    Callsite,
+    /// The item represents a loop summary or loop exit.
+    LoopSummary,
+    /// The item may invalidate a relevant fact.
+    Invalidation,
+    /// The item may affect relevant state but is not modeled precisely yet.
+    UnknownRelevantEffect,
+}
+
+/// Reason for conservatively forgetting relevant state.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum HavocReason {
+    /// A call may modify relevant state but has no summary yet.
+    UnknownCall,
+    /// A loop may modify relevant state but has no summary yet.
+    LoopWithoutSummary,
+    /// A write may alias relevant state.
+    MayAliasWrite,
+    /// A relevant statement or terminator is not supported yet.
+    UnsupportedEffect,
+}
+
+/// Base of a contract/MIR place tracked by relevance.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub enum PlaceBaseKey {
+    /// MIR return local `_0`.
+    Return,
+    /// MIR local by numeric index.
+    Local(usize),
+    /// Callee argument by index before callsite binding.
+    Arg(usize),
+}
+
+/// Projection-insensitive enough place key for relevance tracking.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct PlaceKey {
+    /// Base local/argument of the place.
+    pub base: PlaceBaseKey,
+    /// Field projections kept from the contract place.
+    pub fields: Vec<usize>,
+}
+
+impl PlaceKey {
+    /// Build a relevance place key from a parsed contract place.
+    pub fn from_contract_place(place: &ContractPlace<'_>) -> Self {
+        Self {
+            base: match place.base {
+                PlaceBase::Return => PlaceBaseKey::Return,
+                PlaceBase::Arg(index) => PlaceBaseKey::Arg(index),
+                PlaceBase::Local(local) => PlaceBaseKey::Local(local),
+            },
+            fields: place
+                .projections
+                .iter()
+                .map(|projection| match projection {
+                    ContractProjection::Field { index, .. } => *index,
+                })
+                .collect(),
+        }
+    }
+
+    /// Return the MIR local represented by this key when it is already known.
+    pub fn local(&self) -> Option<Local> {
+        match self.base {
+            PlaceBaseKey::Return => Some(Local::from_usize(0)),
+            PlaceBaseKey::Local(local) => Some(Local::from_usize(local)),
+            PlaceBaseKey::Arg(_) => None,
+        }
+    }
+}
+
+/// Set of roots that can make MIR evidence relevant.
+#[derive(Clone, Debug, Default)]
+pub struct RelevanceSet {
+    /// Contract-level places, including callee arguments before binding.
+    pub places: FxHashSet<PlaceKey>,
+    /// MIR locals that are already known from local contract places.
+    pub locals: FxHashSet<Local>,
+}
+
+impl RelevanceSet {
+    /// Create an empty relevance set.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Extract initial relevance roots from a required property.
+    pub fn from_property(property: &Property<'_>) -> Self {
+        let mut set = Self::new();
+        set.collect_property(property);
+        set
+    }
+
+    /// Return true when no roots have been collected.
+    pub fn is_empty(&self) -> bool {
+        self.places.is_empty() && self.locals.is_empty()
+    }
+
+    /// Return the number of contract-level places in this set.
+    pub fn place_count(&self) -> usize {
+        self.places.len()
+    }
+
+    /// Return the number of MIR locals in this set.
+    pub fn local_count(&self) -> usize {
+        self.locals.len()
+    }
+
+    /// Insert a MIR local as a relevance root.
+    pub fn insert_local(&mut self, local: Local) {
+        self.locals.insert(local);
+        self.places.insert(PlaceKey {
+            base: if local.as_usize() == 0 {
+                PlaceBaseKey::Return
+            } else {
+                PlaceBaseKey::Local(local.as_usize())
+            },
+            fields: Vec::new(),
+        });
+    }
+
+    /// Insert a contract place as a relevance root.
+    pub fn insert_contract_place(&mut self, place: &ContractPlace<'_>) {
+        self.insert_place_key(PlaceKey::from_contract_place(place));
+    }
+
+    /// Insert a prebuilt place key as a relevance root.
+    pub fn insert_place_key(&mut self, place: PlaceKey) {
+        if let Some(local) = place.local() {
+            self.locals.insert(local);
+        }
+        self.places.insert(place);
+    }
+
+    /// Merge another relevance set into this one.
+    pub fn extend(&mut self, other: RelevanceSet) {
+        self.places.extend(other.places);
+        self.locals.extend(other.locals);
+    }
+
+    /// Collect all roots mentioned by a property.
+    fn collect_property(&mut self, property: &Property<'_>) {
+        for (arg_index, arg) in property.args.iter().enumerate() {
+            if self.collect_target_argument_root(&property.kind, arg_index, arg) {
+                continue;
+            }
+            self.collect_property_arg(arg);
+        }
+    }
+
+    /// Collect a numeric std-contract target argument as a callee argument root.
+    ///
+    /// The bundled std contract database currently uses strings such as `"0"`
+    /// for "callee argument 0".  The generic contract parser treats that as a
+    /// numeric constant.  For properties whose first argument is a target place,
+    /// this helper recovers the intended argument root without changing the
+    /// contract layer.
+    fn collect_target_argument_root(
+        &mut self,
+        kind: &PropertyKind,
+        arg_index: usize,
+        arg: &PropertyArg<'_>,
+    ) -> bool {
+        if !is_target_argument_index(kind, arg_index) {
+            return false;
+        }
+        let PropertyArg::Expr(ContractExpr::Const(value)) = arg else {
+            return false;
+        };
+        let Ok(index) = usize::try_from(*value) else {
+            return false;
+        };
+        self.insert_place_key(PlaceKey {
+            base: PlaceBaseKey::Arg(index),
+            fields: Vec::new(),
+        });
+        true
+    }
+
+    /// Collect all roots mentioned by a property argument.
+    fn collect_property_arg(&mut self, arg: &PropertyArg<'_>) {
+        match arg {
+            PropertyArg::Place(place) => self.insert_contract_place(place),
+            PropertyArg::Expr(expr) => self.collect_contract_expr(expr),
+            PropertyArg::Predicates(predicates) => {
+                for predicate in predicates {
+                    self.collect_numeric_predicate(predicate);
+                }
+            }
+            PropertyArg::Ty(_) | PropertyArg::Ident(_) => {}
+        }
+    }
+
+    /// Collect all roots mentioned by a numeric predicate.
+    fn collect_numeric_predicate(&mut self, predicate: &NumericPredicate<'_>) {
+        self.collect_contract_expr(&predicate.lhs);
+        self.collect_contract_expr(&predicate.rhs);
+    }
+
+    /// Collect all roots mentioned by a contract expression.
+    fn collect_contract_expr(&mut self, expr: &ContractExpr<'_>) {
+        match expr {
+            ContractExpr::Place(place) => self.insert_contract_place(place),
+            ContractExpr::Binary { lhs, rhs, .. } => {
+                self.collect_contract_expr(lhs);
+                self.collect_contract_expr(rhs);
+            }
+            ContractExpr::Unary { expr, .. } => self.collect_contract_expr(expr),
+            ContractExpr::Const(_)
+            | ContractExpr::SizeOf(_)
+            | ContractExpr::AlignOf(_)
+            | ContractExpr::Unknown => {}
+        }
+    }
+}
+
+/// Return whether an argument index is a target-place position for a property.
+fn is_target_argument_index(kind: &PropertyKind, arg_index: usize) -> bool {
+    match kind {
+        PropertyKind::NonOverlap | PropertyKind::Alias => arg_index <= 1,
+        PropertyKind::ValidNum | PropertyKind::Unknown => false,
+        _ => arg_index == 0,
+    }
+}

--- a/rapx/src/verify/mod.rs
+++ b/rapx/src/verify/mod.rs
@@ -2,6 +2,7 @@ mod assets_parser;
 mod attr_parser;
 mod contract;
 pub mod driver;
+pub mod evidence;
 mod helpers;
 pub mod path;
 pub mod report;

--- a/rapx/src/verify/mod.rs
+++ b/rapx/src/verify/mod.rs
@@ -1,6 +1,7 @@
 mod assets_parser;
 mod attr_parser;
 mod contract;
+pub mod driver;
 mod helpers;
 pub mod path;
 pub mod target;

--- a/rapx/src/verify/mod.rs
+++ b/rapx/src/verify/mod.rs
@@ -4,4 +4,5 @@ mod contract;
 pub mod driver;
 mod helpers;
 pub mod path;
+pub mod report;
 pub mod target;

--- a/rapx/src/verify/report.rs
+++ b/rapx/src/verify/report.rs
@@ -1,0 +1,67 @@
+//! Diagnostics and summaries for the staged verifier pipeline.
+//!
+//! The driver and later checking stages report their per-path property results
+//! through the types in this module.  Keeping these types here leaves the driver
+//! focused on orchestration.
+
+use rustc_hir::def_id::DefId;
+
+use super::{contract::Property, helpers::CallsiteLocation};
+
+/// Verification status for one required property on one path.
+#[derive(Clone, Debug)]
+pub enum CheckResult {
+    /// The property has been proved for this path.
+    Proved,
+    /// The verifier found a possible violation for this path.
+    Failed,
+    /// The verifier has not implemented or completed the proof for this path.
+    Unknown,
+}
+
+/// Result for one required property along one path to a callsite.
+#[derive(Clone, Debug)]
+pub struct PropertyCheckResult<'tcx> {
+    /// Unsafe callsite being checked.
+    pub callsite: CallsiteLocation,
+    /// Index of the path in the callsite path set.
+    pub path_index: usize,
+    /// Required property checked on this path.
+    pub property: Property<'tcx>,
+    /// Current verification status.
+    pub result: CheckResult,
+}
+
+/// Verification report for one function target.
+#[derive(Clone, Debug)]
+pub struct VerificationReport<'tcx> {
+    /// Function that was verified.
+    pub function: DefId,
+    /// Per-path property results emitted by the verifier.
+    pub results: Vec<PropertyCheckResult<'tcx>>,
+}
+
+impl<'tcx> VerificationReport<'tcx> {
+    /// Create an empty report for a function target.
+    pub fn new(function: DefId) -> Self {
+        Self {
+            function,
+            results: Vec::new(),
+        }
+    }
+
+    /// Add one path/property check result to this report.
+    pub fn push(&mut self, result: PropertyCheckResult<'tcx>) {
+        self.results.push(result);
+    }
+
+    /// Return the number of check results in this report.
+    pub fn len(&self) -> usize {
+        self.results.len()
+    }
+
+    /// Return true when this report contains no check results.
+    pub fn is_empty(&self) -> bool {
+        self.results.is_empty()
+    }
+}


### PR DESCRIPTION
## Core updates

- Added `verify::driver` as the orchestration layer for the staged verifier pipeline.

- Added `VerifyDriver::verify_function` as the main pipeline entry.

- Added `verify::report` for check results and verification summaries.

- Added `verify::evidence` with the initial backward-evidence data model.


I think we could orchestrate the structure like this:
```
verify/
----------- key components ------------
  driver.rs      // pipeline orchestration
  target.rs      // target/contracts collection
  assets_parser.rs
  attr_parser.rs  // tow parsers
  path.rs        // path extraction
  evidence.rs    // backward evidence reduction
  replay.rs      // forward abstract replay
  smt.rs         // SMT lowering and solver result
  report.rs      // diagnostics and summaries
```