### PR TITLE
refactor evidence to backward_visitor

### DIFF
--- a/rapx/src/verify/backward_visit.rs
+++ b/rapx/src/verify/backward_visit.rs
@@ -1,8 +1,9 @@
-//! Backward evidence data model for the staged verifier.
+//! Backward path visitor for the staged verifier.
 //!
-//! This module defines the structures used by the future backward evidence
-//! reducer.  It also provides property-root extraction without making the
-//! contract layer depend on the evidence layer.
+//! This module walks a finite path backward from an unsafe callsite and keeps
+//! only MIR statements, terminators, and path steps that can affect the required
+//! property. It also extracts property roots without making the contract layer
+//! depend on the backward visitor.
 
 use rustc_data_structures::fx::FxHashSet;
 use rustc_middle::mir::{
@@ -20,55 +21,55 @@ use super::{
     path::{Path, PathStep},
 };
 
-/// Entry point for future backward evidence reduction.
-pub struct EvidenceReducer<'tcx> {
+/// Entry point for backward path visiting.
+pub struct BackwardVisitor<'tcx> {
     tcx: TyCtxt<'tcx>,
 }
 
-impl<'tcx> EvidenceReducer<'tcx> {
-    /// Create an evidence reducer over the current compiler type context.
+impl<'tcx> BackwardVisitor<'tcx> {
+    /// Create a backward visitor over the current compiler type context.
     pub fn new(tcx: TyCtxt<'tcx>) -> Self {
         Self { tcx }
     }
 
-    /// Return the compiler type context owned by this reducer.
+    /// Return the compiler type context owned by this visitor.
     pub fn tcx(&self) -> TyCtxt<'tcx> {
         self.tcx
     }
 
-    /// Build the initial reduced-evidence object for a path and property.
-    pub fn seed(
+    /// Build the initial relevant-MIR item set for a path and property.
+    pub fn start_visit(
         &self,
         callsite: CallsiteLocation,
         path: &Path,
         property: &Property<'tcx>,
-    ) -> ReducedEvidence<'tcx> {
-        ReducedEvidence {
+    ) -> RelevantMirItems<'tcx> {
+        RelevantMirItems {
             callsite,
             property: property.clone(),
             path: path.clone(),
             items: Vec::new(),
-            roots: RelevanceSet::from_property(property),
+            roots: RelevantPlaces::from_property(property),
         }
     }
 
-    /// Reduce one `(callsite, path, property)` item to path-specific evidence.
+    /// Visit one `(callsite, path, property)` item backward.
     ///
-    /// The reducer walks the path backward from the unsafe callsite, starting
+    /// The visitor walks the path backward from the unsafe callsite, starting
     /// from the roots mentioned by the required property.  Statements defining
     /// relevant locals are retained and their uses become the next relevance
     /// frontier.  Relevant branch conditions, calls, drops, and loop exits are
-    /// retained as conservative evidence for later replay.
-    pub fn reduce(
+    /// retained as conservative inputs for later replay.
+    pub fn visit(
         &self,
         callsite: &Callsite<'tcx>,
         path: &Path,
         property: &Property<'tcx>,
-    ) -> ReducedEvidence<'tcx> {
-        let mut evidence = self.seed(callsite.location(), path, property);
-        bind_callsite_roots(&mut evidence.roots, callsite);
+    ) -> RelevantMirItems<'tcx> {
+        let mut visit = self.start_visit(callsite.location(), path, property);
+        bind_callsite_roots(&mut visit.roots, callsite);
 
-        let mut relevant = evidence.roots.clone();
+        let mut relevant = visit.roots.clone();
         let mut items = Vec::new();
         let body = self.tcx.optimized_mir(callsite.caller);
 
@@ -78,15 +79,15 @@ impl<'tcx> EvidenceReducer<'tcx> {
                     if *location != callsite.location() {
                         continue;
                     }
-                    items.push(EvidenceItem::Terminator {
+                    items.push(BackwardItem::Terminator {
                         block: location.block,
-                        kind: EvidenceKind::Callsite,
+                        kind: KeepReason::Callsite,
                     });
                 }
                 PathStep::Block(block) => {
                     let block_data = &body.basic_blocks[*block];
                     if *block != callsite.block {
-                        self.reduce_terminator(
+                        self.visit_terminator(
                             *block,
                             block_data.terminator(),
                             &mut relevant,
@@ -96,7 +97,7 @@ impl<'tcx> EvidenceReducer<'tcx> {
                     for (statement_index, statement) in
                         block_data.statements.iter().enumerate().rev()
                     {
-                        self.reduce_statement(
+                        self.visit_statement(
                             *block,
                             statement_index,
                             statement,
@@ -106,37 +107,37 @@ impl<'tcx> EvidenceReducer<'tcx> {
                     }
                 }
                 PathStep::LoopExit { .. } => {
-                    items.push(EvidenceItem::Havoc {
-                        reason: HavocReason::LoopWithoutSummary,
+                    items.push(BackwardItem::Forget {
+                        reason: ForgetReason::LoopWithoutSummary,
                     });
-                    items.push(EvidenceItem::PathStep {
+                    items.push(BackwardItem::PathStep {
                         step: step.clone(),
-                        kind: EvidenceKind::LoopSummary,
+                        kind: KeepReason::LoopExit,
                     });
                 }
             }
         }
 
         items.reverse();
-        evidence.items = items;
-        evidence
+        visit.items = items;
+        visit
     }
 
-    /// Reduce one MIR statement against the current relevance frontier.
-    fn reduce_statement(
+    /// Visit one MIR statement against the current relevance frontier.
+    fn visit_statement(
         &self,
         block: BasicBlock,
         statement_index: usize,
         statement: &Statement<'tcx>,
-        relevant: &mut RelevanceSet,
-        items: &mut Vec<EvidenceItem<'tcx>>,
+        relevant: &mut RelevantPlaces,
+        items: &mut Vec<BackwardItem<'tcx>>,
     ) {
         let use_def = statement_use_def(statement);
         if use_def.defs.intersects(relevant) {
-            items.push(EvidenceItem::Statement {
+            items.push(BackwardItem::Statement {
                 block,
                 statement_index,
-                kind: statement_evidence_kind(statement),
+                kind: statement_keep_reason(statement),
             });
             relevant.remove_all(&use_def.defs);
             relevant.extend(use_def.uses);
@@ -144,38 +145,38 @@ impl<'tcx> EvidenceReducer<'tcx> {
         }
 
         if statement_invalidates_relevant(statement, relevant) {
-            items.push(EvidenceItem::Statement {
+            items.push(BackwardItem::Statement {
                 block,
                 statement_index,
-                kind: EvidenceKind::Invalidation,
+                kind: KeepReason::Invalidation,
             });
         } else if use_def.uses.intersects(relevant) && statement_can_refine(statement) {
-            items.push(EvidenceItem::Statement {
+            items.push(BackwardItem::Statement {
                 block,
                 statement_index,
-                kind: EvidenceKind::RuntimeCheck,
+                kind: KeepReason::RuntimeCheck,
             });
         }
     }
 
-    /// Reduce one MIR terminator against the current relevance frontier.
-    fn reduce_terminator(
+    /// Visit one MIR terminator against the current relevance frontier.
+    fn visit_terminator(
         &self,
         block: BasicBlock,
         terminator: &Terminator<'tcx>,
-        relevant: &mut RelevanceSet,
-        items: &mut Vec<EvidenceItem<'tcx>>,
+        relevant: &mut RelevantPlaces,
+        items: &mut Vec<BackwardItem<'tcx>>,
     ) {
         let use_def = terminator_use_def(terminator);
         if use_def.defs.intersects(relevant) {
             if terminator_may_havoc(terminator) {
-                items.push(EvidenceItem::Havoc {
-                    reason: HavocReason::UnknownCall,
+                items.push(BackwardItem::Forget {
+                    reason: ForgetReason::UnknownCall,
                 });
             }
-            items.push(EvidenceItem::Terminator {
+            items.push(BackwardItem::Terminator {
                 block,
-                kind: terminator_definition_kind(terminator),
+                kind: terminator_definition_reason(terminator),
             });
             relevant.remove_all(&use_def.defs);
             relevant.extend(use_def.uses);
@@ -184,13 +185,13 @@ impl<'tcx> EvidenceReducer<'tcx> {
 
         if use_def.uses.intersects(relevant) {
             if terminator_may_havoc(terminator) {
-                items.push(EvidenceItem::Havoc {
-                    reason: HavocReason::UnknownCall,
+                items.push(BackwardItem::Forget {
+                    reason: ForgetReason::UnknownCall,
                 });
             }
-            items.push(EvidenceItem::Terminator {
+            items.push(BackwardItem::Terminator {
                 block,
-                kind: terminator_use_kind(terminator),
+                kind: terminator_use_reason(terminator),
             });
         }
     }
@@ -198,93 +199,90 @@ impl<'tcx> EvidenceReducer<'tcx> {
 
 /// Definitions and uses collected from one MIR item.
 #[derive(Clone, Debug, Default)]
-pub struct UseDef {
+pub struct DefUse {
     /// Places defined or invalidated by the MIR item.
-    pub defs: RelevanceSet,
+    pub defs: RelevantPlaces,
     /// Places read by the MIR item.
-    pub uses: RelevanceSet,
+    pub uses: RelevantPlaces,
 }
 
-impl UseDef {
+impl DefUse {
     /// Create an empty use-def summary.
     pub fn new() -> Self {
         Self::default()
     }
 }
 
-/// Reduced evidence retained for one `(callsite, path, property)` item.
+/// MIR items relevant to one `(callsite, path, property)` item.
 #[derive(Clone, Debug)]
-pub struct ReducedEvidence<'tcx> {
+pub struct RelevantMirItems<'tcx> {
     /// Unsafe callsite whose obligation is being checked.
     pub callsite: CallsiteLocation,
     /// Required property that determines the relevance roots.
     pub property: Property<'tcx>,
-    /// Path being reduced.
+    /// Path being visited.
     pub path: Path,
-    /// Evidence retained from the path.
-    pub items: Vec<EvidenceItem<'tcx>>,
+    /// Items kept from the path.
+    pub items: Vec<BackwardItem<'tcx>>,
     /// Initial roots extracted from the property.
-    pub roots: RelevanceSet,
+    pub roots: RelevantPlaces,
 }
 
-impl<'tcx> ReducedEvidence<'tcx> {
-    /// Append one evidence item to the reduced path.
-    pub fn push(&mut self, item: EvidenceItem<'tcx>) {
+impl<'tcx> RelevantMirItems<'tcx> {
+    /// Append one kept item to the visited path.
+    pub fn push(&mut self, item: BackwardItem<'tcx>) {
         self.items.push(item);
     }
 
-    /// Return true when no MIR/path evidence has been retained yet.
+    /// Return true when no MIR/path item has been kept yet.
     pub fn is_empty(&self) -> bool {
         self.items.is_empty()
     }
 }
 
-/// One retained evidence item from a path.
+/// One item kept while walking a path backward.
 #[derive(Clone, Debug)]
-pub enum EvidenceItem<'tcx> {
+pub enum BackwardItem<'tcx> {
     /// A MIR statement retained from a basic block.
     Statement {
         block: BasicBlock,
         statement_index: usize,
-        kind: EvidenceKind,
+        kind: KeepReason,
     },
     /// A MIR terminator retained from a basic block.
-    Terminator {
-        block: BasicBlock,
-        kind: EvidenceKind,
-    },
-    /// A path-level step retained as structural evidence.
-    PathStep { step: PathStep, kind: EvidenceKind },
-    /// A contract fact retained as evidence.
+    Terminator { block: BasicBlock, kind: KeepReason },
+    /// A path-level step retained as structural context.
+    PathStep { step: PathStep, kind: KeepReason },
+    /// A contract fact retained as a visit input.
     ContractFact { property: Property<'tcx> },
     /// A conservative loss of precision for relevant state.
-    Havoc { reason: HavocReason },
+    Forget { reason: ForgetReason },
 }
 
 /// Why a retained item is relevant.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum EvidenceKind {
+pub enum KeepReason {
     /// The item defines a relevant place.
     Definition,
     /// The item contributes a branch/path condition.
     PathCondition,
     /// The item contributes pointer provenance or pointer arithmetic.
-    PointerProvenance,
+    PointerFlow,
     /// The item refines state through a runtime check.
     RuntimeCheck,
     /// The item is the unsafe callsite being checked.
     Callsite,
     /// The item represents a loop summary or loop exit.
-    LoopSummary,
+    LoopExit,
     /// The item may invalidate a relevant fact.
     Invalidation,
     /// The item may affect relevant state but is not modeled precisely yet.
-    UnknownRelevantEffect,
+    UnknownEffect,
 }
 
 /// Reason for conservatively forgetting relevant state.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum HavocReason {
+pub enum ForgetReason {
     /// A call may modify relevant state but has no summary yet.
     UnknownCall,
     /// A loop may modify relevant state but has no summary yet.
@@ -363,16 +361,16 @@ impl PlaceKey {
     }
 }
 
-/// Set of roots that can make MIR evidence relevant.
+/// Set of places that make MIR items relevant to a property.
 #[derive(Clone, Debug, Default)]
-pub struct RelevanceSet {
+pub struct RelevantPlaces {
     /// Contract-level places, including callee arguments before binding.
     pub places: FxHashSet<PlaceKey>,
     /// MIR locals that are already known from local contract places.
     pub locals: FxHashSet<Local>,
 }
 
-impl RelevanceSet {
+impl RelevantPlaces {
     /// Create an empty relevance set.
     pub fn new() -> Self {
         Self::default()
@@ -432,19 +430,19 @@ impl RelevanceSet {
     }
 
     /// Merge another relevance set into this one.
-    pub fn extend(&mut self, other: RelevanceSet) {
+    pub fn extend(&mut self, other: RelevantPlaces) {
         self.places.extend(other.places);
         self.locals.extend(other.locals);
     }
 
     /// Return true if this set shares any known root with `other`.
-    pub fn intersects(&self, other: &RelevanceSet) -> bool {
+    pub fn intersects(&self, other: &RelevantPlaces) -> bool {
         self.locals.iter().any(|local| other.locals.contains(local))
             || self.places.iter().any(|place| other.places.contains(place))
     }
 
     /// Remove all roots contained in `other` from this set.
-    pub fn remove_all(&mut self, other: &RelevanceSet) {
+    pub fn remove_all(&mut self, other: &RelevantPlaces) {
         for local in &other.locals {
             self.locals.remove(local);
             self.places.retain(|place| place.local() != Some(*local));
@@ -543,7 +541,7 @@ fn is_target_argument_index(kind: &PropertyKind, arg_index: usize) -> bool {
 }
 
 /// Bind callee-argument roots in std contracts to concrete MIR call operands.
-fn bind_callsite_roots(relevance: &mut RelevanceSet, callsite: &Callsite<'_>) {
+fn bind_callsite_roots(relevance: &mut RelevantPlaces, callsite: &Callsite<'_>) {
     let argument_roots: Vec<usize> = relevance
         .places
         .iter()
@@ -561,8 +559,8 @@ fn bind_callsite_roots(relevance: &mut RelevanceSet, callsite: &Callsite<'_>) {
 }
 
 /// Collect definitions and uses for one MIR statement.
-fn statement_use_def<'tcx>(statement: &Statement<'tcx>) -> UseDef {
-    let mut use_def = UseDef::new();
+fn statement_use_def<'tcx>(statement: &Statement<'tcx>) -> DefUse {
+    let mut use_def = DefUse::new();
     match &statement.kind {
         StatementKind::Assign(box (place, rvalue)) => {
             use_def.defs.insert_mir_place(place);
@@ -579,8 +577,8 @@ fn statement_use_def<'tcx>(statement: &Statement<'tcx>) -> UseDef {
 }
 
 /// Collect definitions and uses for one MIR terminator.
-fn terminator_use_def<'tcx>(terminator: &Terminator<'tcx>) -> UseDef {
-    let mut use_def = UseDef::new();
+fn terminator_use_def<'tcx>(terminator: &Terminator<'tcx>) -> DefUse {
+    let mut use_def = DefUse::new();
     match &terminator.kind {
         TerminatorKind::Call {
             func,
@@ -609,8 +607,8 @@ fn terminator_use_def<'tcx>(terminator: &Terminator<'tcx>) -> UseDef {
 }
 
 /// Collect all MIR roots used by an rvalue.
-fn rvalue_uses<'tcx>(rvalue: &Rvalue<'tcx>) -> RelevanceSet {
-    let mut uses = RelevanceSet::new();
+fn rvalue_uses<'tcx>(rvalue: &Rvalue<'tcx>) -> RelevantPlaces {
+    let mut uses = RelevantPlaces::new();
     match rvalue {
         Rvalue::Use(operand)
         | Rvalue::Repeat(operand, _)
@@ -641,8 +639,8 @@ fn rvalue_uses<'tcx>(rvalue: &Rvalue<'tcx>) -> RelevanceSet {
 }
 
 /// Collect all MIR roots used by an operand.
-fn operand_uses<'tcx>(operand: &Operand<'tcx>) -> RelevanceSet {
-    let mut uses = RelevanceSet::new();
+fn operand_uses<'tcx>(operand: &Operand<'tcx>) -> RelevantPlaces {
+    let mut uses = RelevantPlaces::new();
     match operand {
         Operand::Copy(place) | Operand::Move(place) => {
             uses.extend(place_uses(place));
@@ -653,16 +651,16 @@ fn operand_uses<'tcx>(operand: &Operand<'tcx>) -> RelevanceSet {
 }
 
 /// Collect the base and projection-index roots used by a MIR place.
-fn place_uses(place: &Place<'_>) -> RelevanceSet {
-    let mut uses = RelevanceSet::new();
+fn place_uses(place: &Place<'_>) -> RelevantPlaces {
+    let mut uses = RelevantPlaces::new();
     uses.insert_mir_place(place);
     uses.extend(place_projection_uses(place));
     uses
 }
 
 /// Collect only the index roots used by a place projection.
-fn place_projection_uses(place: &Place<'_>) -> RelevanceSet {
-    let mut uses = RelevanceSet::new();
+fn place_projection_uses(place: &Place<'_>) -> RelevantPlaces {
+    let mut uses = RelevantPlaces::new();
     for projection in place.projection {
         if let ProjectionElem::Index(local) = projection {
             uses.insert_local(local);
@@ -671,19 +669,19 @@ fn place_projection_uses(place: &Place<'_>) -> RelevanceSet {
     uses
 }
 
-/// Classify a retained statement by the kind of evidence it contributes.
-fn statement_evidence_kind(statement: &Statement<'_>) -> EvidenceKind {
+/// Classify why a backward visit keeps a statement.
+fn statement_keep_reason(statement: &Statement<'_>) -> KeepReason {
     match &statement.kind {
         StatementKind::Assign(box (_, rvalue)) => match rvalue {
             Rvalue::Ref(_, _, _)
             | Rvalue::RawPtr(_, _)
             | Rvalue::Cast(_, _, _)
             | Rvalue::CopyForDeref(_)
-            | Rvalue::BinaryOp(_, _) => EvidenceKind::PointerProvenance,
-            _ => EvidenceKind::Definition,
+            | Rvalue::BinaryOp(_, _) => KeepReason::PointerFlow,
+            _ => KeepReason::Definition,
         },
-        StatementKind::StorageDead(_) => EvidenceKind::Invalidation,
-        _ => EvidenceKind::Definition,
+        StatementKind::StorageDead(_) => KeepReason::Invalidation,
+        _ => KeepReason::Definition,
     }
 }
 
@@ -699,7 +697,7 @@ fn statement_can_refine(statement: &Statement<'_>) -> bool {
 }
 
 /// Return true if a statement invalidates currently relevant state.
-fn statement_invalidates_relevant(statement: &Statement<'_>, relevant: &RelevanceSet) -> bool {
+fn statement_invalidates_relevant(statement: &Statement<'_>, relevant: &RelevantPlaces) -> bool {
     match &statement.kind {
         StatementKind::StorageDead(local) => relevant.locals.contains(local),
         _ => false,
@@ -707,22 +705,22 @@ fn statement_invalidates_relevant(statement: &Statement<'_>, relevant: &Relevanc
 }
 
 /// Classify a retained terminator that defines a relevant place.
-fn terminator_definition_kind(terminator: &Terminator<'_>) -> EvidenceKind {
+fn terminator_definition_reason(terminator: &Terminator<'_>) -> KeepReason {
     match terminator.kind {
-        TerminatorKind::Call { .. } => EvidenceKind::UnknownRelevantEffect,
-        _ => EvidenceKind::Definition,
+        TerminatorKind::Call { .. } => KeepReason::UnknownEffect,
+        _ => KeepReason::Definition,
     }
 }
 
 /// Classify a retained terminator that uses a relevant place.
-fn terminator_use_kind(terminator: &Terminator<'_>) -> EvidenceKind {
+fn terminator_use_reason(terminator: &Terminator<'_>) -> KeepReason {
     match terminator.kind {
         TerminatorKind::SwitchInt { .. } | TerminatorKind::Assert { .. } => {
-            EvidenceKind::PathCondition
+            KeepReason::PathCondition
         }
-        TerminatorKind::Drop { .. } => EvidenceKind::Invalidation,
-        TerminatorKind::Call { .. } => EvidenceKind::UnknownRelevantEffect,
-        _ => EvidenceKind::UnknownRelevantEffect,
+        TerminatorKind::Drop { .. } => KeepReason::Invalidation,
+        TerminatorKind::Call { .. } => KeepReason::UnknownEffect,
+        _ => KeepReason::UnknownEffect,
     }
 }
 

--- a/rapx/src/verify/driver.rs
+++ b/rapx/src/verify/driver.rs
@@ -3,16 +3,16 @@
 //! The target collector owns selected functions and their callee requirements.
 //! The path extractor upgrades a function CFG into loop-aware path metadata.
 //! This module keeps those pieces together for one function target and exposes
-//! callsite-level views for later evidence, replay, and SMT stages.
+//! callsite-level views for later backward visits, replay, and SMT stages.
 
 use rustc_data_structures::fx::FxHashMap;
 use rustc_middle::ty::TyCtxt;
 
 use super::{
+    backward_visit::BackwardVisitor,
     contract::Property,
-    evidence::EvidenceReducer,
     helpers::Callsite,
-    path::{Path, PathExtractor, PathMetaInfo},
+    path::{FunctionPaths, Path, PathExtractor},
     report::{CheckResult, PropertyCheckResult, VerificationReport},
     target::FunctionTarget,
 };
@@ -21,7 +21,7 @@ use super::{
 pub struct VerifyDriver<'target, 'tcx> {
     tcx: TyCtxt<'tcx>,
     target: &'target FunctionTarget<'tcx>,
-    path_info: PathMetaInfo<'tcx>,
+    path_info: FunctionPaths<'tcx>,
     properties_to_verify: FxHashMap<super::helpers::CallsiteLocation, &'target [Property<'tcx>]>,
 }
 
@@ -49,7 +49,7 @@ impl<'target, 'tcx> VerifyDriver<'target, 'tcx> {
     }
 
     /// Return the loop-aware path metadata managed by this driver.
-    pub fn path_info(&self) -> &PathMetaInfo<'tcx> {
+    pub fn path_info(&self) -> &FunctionPaths<'tcx> {
         &self.path_info
     }
 
@@ -57,17 +57,17 @@ impl<'target, 'tcx> VerifyDriver<'target, 'tcx> {
     ///
     /// This method is the main driver entry for later verification stages.  It
     /// currently walks `(callsite, path, property)` items and records an
-    /// `Unknown` result for each one.  Evidence reduction, abstract replay, and
+    /// `Unknown` result for each one. Backward visiting, abstract replay, and
     /// SMT checking can replace the placeholder result inside this loop without
     /// changing the surrounding control flow.
     pub fn verify_function(&self) -> VerificationReport<'tcx> {
         let mut report = VerificationReport::new(self.target.def_id);
-        let reducer = EvidenceReducer::new(self.tcx);
+        let visitor = BackwardVisitor::new(self.tcx);
 
         for view in self.iter_callsite_checks() {
             for (path_index, path) in view.paths.iter().enumerate() {
                 for property in view.properties {
-                    let _evidence = reducer.reduce(view.callsite, path, property);
+                    let _visit = visitor.visit(view.callsite, path, property);
                     report.push(PropertyCheckResult {
                         callsite: view.callsite.location(),
                         path_index,

--- a/rapx/src/verify/mod.rs
+++ b/rapx/src/verify/mod.rs
@@ -1,8 +1,8 @@
 mod assets_parser;
 mod attr_parser;
+pub mod backward_visit;
 mod contract;
 pub mod driver;
-pub mod evidence;
 mod helpers;
 pub mod path;
 pub mod report;

--- a/rapx/src/verify/path.rs
+++ b/rapx/src/verify/path.rs
@@ -6,8 +6,6 @@
 //! inside a loop, the path starts at the loop header and reaches the callsite
 //! within one loop iteration.
 
-use std::fmt;
-
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_hir::def_id::DefId;
 use rustc_middle::{mir::BasicBlock, ty::TyCtxt};
@@ -20,8 +18,8 @@ use super::helpers::{CFG, Callsite, CallsiteLocation};
 pub struct PathExtractor<'tcx> {
     cfg: CFG,
     callsites: Vec<Callsite<'tcx>>,
-    loops: Vec<LoopInfo>,
-    block_to_loop: FxHashMap<BasicBlock, LoopId>,
+    loops: Vec<Loop>,
+    block_to_loop: FxHashMap<BasicBlock, BasicBlock>,
     paths: FxHashMap<CallsiteLocation, Vec<Path>>,
 }
 
@@ -38,12 +36,12 @@ impl<'tcx> PathExtractor<'tcx> {
     }
 
     /// Run loop detection and path extraction, then return path metadata.
-    pub fn run(mut self) -> PathMetaInfo<'tcx> {
+    pub fn run(mut self) -> FunctionPaths<'tcx> {
         self.find_loops();
         self.find_paths();
-        PathMetaInfo {
-            loops: LoopMetaInfo::new(self.loops),
-            callsite_paths: CallsitePathInfo::new(self.callsites, self.paths),
+        FunctionPaths {
+            loops: Loops::new(self.loops),
+            callsite_paths: CallsitePaths::new(self.callsites, self.paths),
         }
     }
 
@@ -79,8 +77,8 @@ impl<'tcx> PathExtractor<'tcx> {
         by_block: &FxHashMap<BasicBlock, CallsiteLocation>,
     ) -> Vec<Path> {
         let target = callsite.location();
-        if let Some(loop_id) = self.block_to_loop.get(&callsite.block).copied() {
-            self.find_loop_paths(loop_id, target, callsite.block)
+        if let Some(header) = self.block_to_loop.get(&callsite.block).copied() {
+            self.find_loop_paths(header, target, callsite.block)
         } else {
             self.find_entry_paths(target, callsite.block, by_block)
         }
@@ -151,12 +149,12 @@ impl<'tcx> PathExtractor<'tcx> {
                 break;
             }
 
-            if let Some(loop_id) = self.block_to_loop.get(&next).copied() {
-                if self.block_to_loop.get(&target_block).copied() == Some(loop_id) {
+            if let Some(header) = self.block_to_loop.get(&next).copied() {
+                if self.block_to_loop.get(&target_block).copied() == Some(header) {
                     continue;
                 }
                 self.follow_loop_exits(
-                    loop_id,
+                    header,
                     target,
                     target_block,
                     by_block,
@@ -195,7 +193,7 @@ impl<'tcx> PathExtractor<'tcx> {
     /// It records the selected exit and resumes the DFS at the exit destination.
     fn follow_loop_exits(
         &self,
-        loop_id: LoopId,
+        header: BasicBlock,
         target: CallsiteLocation,
         target_block: BasicBlock,
         by_block: &FxHashMap<BasicBlock, CallsiteLocation>,
@@ -204,7 +202,9 @@ impl<'tcx> PathExtractor<'tcx> {
         results: &mut Vec<Path>,
         limit: usize,
     ) {
-        let loop_info = &self.loops[loop_id.index()];
+        let Some(loop_info) = self.loop_by_header(header) else {
+            return;
+        };
         for exit in &loop_info.exits {
             if results.len() >= limit {
                 break;
@@ -214,7 +214,7 @@ impl<'tcx> PathExtractor<'tcx> {
             }
 
             stack.push(PathStep::LoopExit {
-                loop_id,
+                header,
                 from: exit.from,
                 to: exit.to,
             });
@@ -244,19 +244,21 @@ impl<'tcx> PathExtractor<'tcx> {
     /// state.
     fn find_loop_paths(
         &self,
-        loop_id: LoopId,
+        header: BasicBlock,
         target: CallsiteLocation,
         target_block: BasicBlock,
     ) -> Vec<Path> {
         const PATH_LIMIT: usize = 1024;
-        let loop_info = &self.loops[loop_id.index()];
+        let Some(loop_info) = self.loop_by_header(header) else {
+            return Vec::new();
+        };
         let loop_blocks: FxHashSet<BasicBlock> = loop_info.blocks.iter().copied().collect();
         let mut results = Vec::new();
         let mut stack = vec![PathStep::Block(loop_info.header)];
         let mut visited = FxHashSet::default();
         visited.insert(loop_info.header);
         self.dfs_loop_paths(
-            loop_id,
+            header,
             loop_info.header,
             target,
             target_block,
@@ -276,7 +278,7 @@ impl<'tcx> PathExtractor<'tcx> {
     /// reaches a callsite located in the loop body.
     fn dfs_loop_paths(
         &self,
-        loop_id: LoopId,
+        header: BasicBlock,
         current: BasicBlock,
         target: CallsiteLocation,
         target_block: BasicBlock,
@@ -294,7 +296,7 @@ impl<'tcx> PathExtractor<'tcx> {
             stack.push(PathStep::Callsite(target));
             results.push(Path {
                 target,
-                start: PathStart::LoopHeader { loop_id },
+                start: PathStart::LoopHeader { header },
                 steps: stack.clone(),
             });
             stack.pop();
@@ -308,7 +310,7 @@ impl<'tcx> PathExtractor<'tcx> {
             stack.push(PathStep::Block(next));
             visited.insert(next);
             self.dfs_loop_paths(
-                loop_id,
+                header,
                 next,
                 target,
                 target_block,
@@ -322,6 +324,13 @@ impl<'tcx> PathExtractor<'tcx> {
             stack.pop();
         }
     }
+
+    /// Return the detected loop whose header is `header`.
+    fn loop_by_header(&self, header: BasicBlock) -> Option<&Loop> {
+        self.loops
+            .iter()
+            .find(|loop_info| loop_info.header == header)
+    }
 }
 
 /// Path metadata produced by a completed extraction run.
@@ -329,19 +338,19 @@ impl<'tcx> PathExtractor<'tcx> {
 /// This is the path-level view of a function CFG: loop information describes
 /// cyclic regions, while callsite path information maps unsafe callsites to the
 /// finite paths that reach them.
-pub struct PathMetaInfo<'tcx> {
-    loops: LoopMetaInfo,
-    callsite_paths: CallsitePathInfo<'tcx>,
+pub struct FunctionPaths<'tcx> {
+    loops: Loops,
+    callsite_paths: CallsitePaths<'tcx>,
 }
 
-impl<'tcx> PathMetaInfo<'tcx> {
+impl<'tcx> FunctionPaths<'tcx> {
     /// Return loop metadata for this function.
-    pub fn loop_info(&self) -> &LoopMetaInfo {
+    pub fn loop_info(&self) -> &Loops {
         &self.loops
     }
 
     /// Return callsite-to-path metadata for this function.
-    pub fn callsite_paths(&self) -> &CallsitePathInfo<'tcx> {
+    pub fn callsite_paths(&self) -> &CallsitePaths<'tcx> {
         &self.callsite_paths
     }
 
@@ -351,7 +360,7 @@ impl<'tcx> PathMetaInfo<'tcx> {
     }
 
     /// Return all loops detected in the function CFG.
-    pub fn loops(&self) -> &[LoopInfo] {
+    pub fn loops(&self) -> &[Loop] {
         self.loops.loops()
     }
 
@@ -362,18 +371,18 @@ impl<'tcx> PathMetaInfo<'tcx> {
 }
 
 /// Metadata for loop regions discovered in a function CFG.
-pub struct LoopMetaInfo {
-    loops: Vec<LoopInfo>,
+pub struct Loops {
+    loops: Vec<Loop>,
 }
 
-impl LoopMetaInfo {
+impl Loops {
     /// Create loop metadata from detected loops.
-    fn new(loops: Vec<LoopInfo>) -> Self {
+    fn new(loops: Vec<Loop>) -> Self {
         Self { loops }
     }
 
     /// Return all detected loops.
-    pub fn loops(&self) -> &[LoopInfo] {
+    pub fn loops(&self) -> &[Loop] {
         &self.loops
     }
 
@@ -389,12 +398,12 @@ impl LoopMetaInfo {
 }
 
 /// Metadata that maps unsafe callsites to finite verification paths.
-pub struct CallsitePathInfo<'tcx> {
+pub struct CallsitePaths<'tcx> {
     callsites: Vec<Callsite<'tcx>>,
     paths_by_callsite: FxHashMap<CallsiteLocation, Vec<Path>>,
 }
 
-impl<'tcx> CallsitePathInfo<'tcx> {
+impl<'tcx> CallsitePaths<'tcx> {
     /// Create callsite path metadata from callsites and extracted paths.
     fn new(
         callsites: Vec<Callsite<'tcx>>,
@@ -438,10 +447,10 @@ impl Path {
             .iter()
             .map(|step| match step {
                 PathStep::Block(bb) => format!("bb{}", bb.as_usize()),
-                PathStep::LoopExit { loop_id, from, to } => {
+                PathStep::LoopExit { header, from, to } => {
                     format!(
-                        "Loop#{}.exit(bb{} -> bb{})",
-                        loop_id.index(),
+                        "Loop(bb{}).exit(bb{} -> bb{})",
+                        header.as_usize(),
                         from.as_usize(),
                         to.as_usize()
                     )
@@ -461,7 +470,7 @@ pub enum PathStart {
     /// The path starts at the function entry block.
     FunctionEntry,
     /// The path starts at the header of a loop containing the target callsite.
-    LoopHeader { loop_id: LoopId },
+    LoopHeader { header: BasicBlock },
 }
 
 /// One step in a finite verification path.
@@ -471,7 +480,7 @@ pub enum PathStep {
     Block(BasicBlock),
     /// An abstract step that enters a loop and leaves through one exit edge.
     LoopExit {
-        loop_id: LoopId,
+        header: BasicBlock,
         from: BasicBlock,
         to: BasicBlock,
     },
@@ -479,35 +488,10 @@ pub enum PathStep {
     Callsite(CallsiteLocation),
 }
 
-/// Identifier for a detected loop in one function body.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-pub struct LoopId(usize);
-
-impl LoopId {
-    /// Create a loop id from its index in the local loop list.
-    fn new(index: usize) -> Self {
-        Self(index)
-    }
-
-    /// Return the index of this loop id in the local loop list.
-    pub fn index(self) -> usize {
-        self.0
-    }
-}
-
-impl fmt::Display for LoopId {
-    /// Format a loop id as its numeric index.
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-/// Information recorded for one detected loop.
+/// A cyclic SCC that the verifier treats as one loop region.
 #[derive(Clone, Debug)]
-pub struct LoopInfo {
-    /// Local id of this loop.
-    pub id: LoopId,
-    /// Header block chosen for this loop.
+pub struct Loop {
+    /// Header block used as the stable key for this loop.
     pub header: BasicBlock,
     /// Blocks that belong to the loop.
     pub blocks: Vec<BasicBlock>,
@@ -515,8 +499,6 @@ pub struct LoopInfo {
     pub exits: Vec<LoopExit>,
     /// Edges inside the loop that go back to an earlier block or the header.
     pub backedges: Vec<(BasicBlock, BasicBlock)>,
-    /// Current summary status for the loop.
-    pub transfer: LoopTransfer,
 }
 
 /// An edge that leaves a detected loop.
@@ -526,17 +508,6 @@ pub struct LoopExit {
     pub from: BasicBlock,
     /// Destination block outside the loop.
     pub to: BasicBlock,
-}
-
-/// Conservative summary status for a loop.
-#[derive(Clone, Debug)]
-pub enum LoopTransfer {
-    /// The loop has not yet been classified by later verification stages.
-    Unknown,
-    /// The loop can be ignored for the current obligation.
-    Skip,
-    /// The loop may modify relevant state without a precise summary.
-    Havoc,
 }
 
 /// Return true when `block` contains a non-target callsite.
@@ -552,7 +523,7 @@ fn has_other_callsite(
 }
 
 /// Detect loops in a CFG using SCCs.
-fn find_loops(cfg: &CFG) -> (Vec<LoopInfo>, FxHashMap<BasicBlock, LoopId>) {
+fn find_loops(cfg: &CFG) -> (Vec<Loop>, FxHashMap<BasicBlock, BasicBlock>) {
     let mut detector = SccDetector::new(cfg.successors.clone());
     detector.find_scc();
 
@@ -568,7 +539,6 @@ fn find_loops(cfg: &CFG) -> (Vec<LoopInfo>, FxHashMap<BasicBlock, LoopId>) {
             continue;
         }
 
-        let id = LoopId::new(loops.len());
         let header = BasicBlock::from_usize(component[0]);
         let block_set: FxHashSet<usize> = component.iter().copied().collect();
         let mut exits = Vec::new();
@@ -592,16 +562,14 @@ fn find_loops(cfg: &CFG) -> (Vec<LoopInfo>, FxHashMap<BasicBlock, LoopId>) {
         }
 
         for &block_idx in &component {
-            block_to_loop.insert(BasicBlock::from_usize(block_idx), id);
+            block_to_loop.insert(BasicBlock::from_usize(block_idx), header);
         }
 
-        loops.push(LoopInfo {
-            id,
+        loops.push(Loop {
             header,
             blocks: component.into_iter().map(BasicBlock::from_usize).collect(),
             exits,
             backedges,
-            transfer: LoopTransfer::Unknown,
         });
     }
 

--- a/rapx/src/verify/target.rs
+++ b/rapx/src/verify/target.rs
@@ -370,8 +370,7 @@ impl<'tcx> PrepareTargets<'tcx> {
                 .map(|exit| format!("bb{}->bb{}", exit.from.as_usize(), exit.to.as_usize()))
                 .collect();
             rap_info!(
-                "      loop #{}: header=bb{}, body={:?}, exits={:?}",
-                loop_info.id.index(),
+                "      loop bb{}: body={:?}, exits={:?}",
                 loop_info.header.as_usize(),
                 body,
                 exits
@@ -398,11 +397,11 @@ impl<'tcx> PrepareTargets<'tcx> {
             for (path_idx, path) in callsite_paths.iter().enumerate() {
                 let kind = match path.start {
                     PathStart::FunctionEntry => "entry",
-                    PathStart::LoopHeader { loop_id } => {
+                    PathStart::LoopHeader { header } => {
                         rap_info!(
-                            "      path {} kind: loop-header(loop #{})",
+                            "      path {} kind: loop-header(bb{})",
                             path_idx,
-                            loop_id.index()
+                            header.as_usize()
                         );
                         rap_info!("      path {}: {}", path_idx, path.describe());
                         continue;


### PR DESCRIPTION
- Refactor `evidence.rs`
- `LoopInfo` -> `Loop`
- Remove `LoopId`
- Remove `LoopTransfer`